### PR TITLE
fix: node-ptyのプラットフォーム依存問題を解決

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -43,7 +43,8 @@
       "Bash(gh issue view:*)",
       "Bash(git fetch:*)",
       "Bash(gh pr create:*)",
-      "Bash(find:*)"
+      "Bash(find:*)",
+      "Bash(vsce package:*)"
     ],
     "deny": []
   }

--- a/package.json
+++ b/package.json
@@ -263,6 +263,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
+    "postinstall": "npm rebuild",
     "compile": "webpack",
     "watch": "webpack --watch",
     "package": "webpack --mode production --devtool hidden-source-map",
@@ -319,10 +320,12 @@
     "webpack-cli": "^6.0.0"
   },
   "dependencies": {
-    "node-pty": "^1.0.0",
     "process": "^0.11.10",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
     "xterm-addon-web-links": "^0.9.0"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- VS Code拡張機能でnode-ptyのプラットフォーム依存のネイティブバイナリ問題を解決
- macOS、Windows、Linux全プラットフォームでの互換性を確保
- optionalDependenciesとpostinstallスクリプトによる自動リビルド機能を実装

## Test plan
- [ ] macOSでの拡張機能インストールとターミナル動作確認
- [ ] Windowsでの拡張機能インストールとターミナル動作確認  
- [ ] Linuxでの拡張機能インストールとターミナル動作確認
- [ ] VSIXパッケージの正常なインストールとnode-ptyの自動ビルド確認

🤖 Generated with [Claude Code](https://claude.ai/code)