### PR TITLE
fix: Enable mouse text selection in terminal

### DIFF
--- a/src/webview/services/terminal/TerminalScrollbarService.ts
+++ b/src/webview/services/terminal/TerminalScrollbarService.ts
@@ -146,8 +146,8 @@ export class TerminalScrollbarService {
       }
 
       /* Let xterm manage overlay positioning; overriding can misalign hitboxes */
+      /* NOTE: xterm-selection-layer intentionally excluded - it breaks text selection */
       .terminal-container .xterm .xterm-link-layer,
-      .terminal-container .xterm .xterm-selection-layer,
       .terminal-container .xterm .xterm-decoration-container {
         top: initial !important;
         left: initial !important;

--- a/src/webview/types/theme.types.ts
+++ b/src/webview/types/theme.types.ts
@@ -21,7 +21,7 @@ export interface TerminalTheme {
   foreground: string;
   cursor: string;
   cursorAccent?: string;
-  selection: string;
+  selectionBackground: string;
   black: string;
   red: string;
   green: string;
@@ -56,7 +56,7 @@ export const DARK_THEME: TerminalTheme = {
   foreground: '#cccccc',
   cursor: '#aeafad',
   cursorAccent: '#000000',
-  selection: 'rgba(38, 79, 120, 0.5)', // VS Code selection with transparency
+  selectionBackground: 'rgba(38, 79, 120, 0.5)', // VS Code selection with transparency
   black: '#000000',
   red: '#cd3131',
   green: '#0dbc79',
@@ -85,7 +85,7 @@ export const LIGHT_THEME: TerminalTheme = {
   foreground: '#333333',
   cursor: '#000000',
   cursorAccent: '#ffffff',
-  selection: 'rgba(173, 214, 255, 0.5)', // VS Code selection with transparency
+  selectionBackground: 'rgba(173, 214, 255, 0.5)', // VS Code selection with transparency
   black: '#000000',
   red: '#cd3131',
   green: '#00bc00',


### PR DESCRIPTION
## Summary
- Fixed invisible text selection highlight in terminal
- Renamed `selection` to `selectionBackground` in theme types (xterm.js expects this property name)
- Removed `xterm-selection-layer` from CSS positioning reset that was breaking selection rendering

## Problem
Mouse text selection appeared to not work - clicking and dragging to select text showed no visible highlight. The selection was actually happening internally, but was invisible because:
1. xterm.js was using its default white selection color (property name mismatch)
2. CSS was interfering with selection layer positioning

## Test plan
- [x] Click and drag to select text in terminal - blue highlight now visible
- [x] Double-click to select word works
- [x] Cmd+C copies selected text
- [x] Works in both dark and light themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced terminal text selection display and improved overlay element positioning behavior.

* **Chores**
  * Refactored theme property naming for improved consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->