### PR TITLE
fix: resolve webview crash and remove non-public API dependency

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -173,6 +173,11 @@ const webviewConfig = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production'),
+      'process.env.CI': JSON.stringify(process.env.CI || ''),
+      'process.env.BUILD_ARTIFACTSTAGINGDIRECTORY': JSON.stringify(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || ''),
+      'process.env.SNAP': JSON.stringify(''),
+      'process.env.SNAP_REVISION': JSON.stringify(''),
+      'process.env.VSCODE_NLS_CONFIG': JSON.stringify(''),
     }),
     new webpack.ProvidePlugin({
       process: 'process/browser',


### PR DESCRIPTION
## Summary

- **Fix webview crash**: Add webpack DefinePlugin entries for undefined `process.env` variables (`CI`, `BUILD_ARTIFACTSTAGINGDIRECTORY`, `SNAP`, `SNAP_REVISION`, `VSCODE_NLS_CONFIG`) that were causing the webview to crash when accessed
- **Remove non-public API dependency**: Remove usage of `vscode.workspace.onWillSaveState` which is not a public VS Code API and was causing console warnings during extension activation
- **Maintain session persistence**: Session saving now relies on the `deactivate()` function (called by VS Code on shutdown) and `TerminalAutoSaveService` for periodic scrollback caching (every 30s)

## Changes

### webpack.config.js
- Added DefinePlugin entries to define environment variables that may be accessed by bundled code
- Prevents "Cannot read properties of undefined" errors in the webview bundle

### ExtensionPersistenceService.ts
- Removed `onWillSaveStateDisposable` property and related disposal code
- Simplified `setupAutoSave()` method with clear documentation about the persistence strategy
- Session persistence continues to work via `deactivate()` and periodic caching

## Test plan

- [ ] Extension activates without console warnings about onWillSaveState
- [ ] Terminal webview loads successfully without crashes
- [ ] Session persistence works correctly on VS Code reload/shutdown
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified auto-save configuration mechanism for improved reliability.

* **Chores**
  * Updated build configuration with environment variable definitions for better build compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->