### PR TITLE
fix: avoid right-edge clipping in terminal

### DIFF
--- a/src/test/vitest/unit/webview/managers/TerminalAddonManager.test.ts
+++ b/src/test/vitest/unit/webview/managers/TerminalAddonManager.test.ts
@@ -243,7 +243,11 @@ describe('TerminalAddonManager', () => {
         paddingLeft: number = 0,
         paddingRight: number = 0,
         paddingTop: number = 0,
-        paddingBottom: number = 0
+        paddingBottom: number = 0,
+        parentPaddingLeft: number = 0,
+        parentPaddingRight: number = 0,
+        parentPaddingTop: number = 0,
+        parentPaddingBottom: number = 0
       ) => {
         const parent = document.createElement('div');
         const element = document.createElement('div');
@@ -256,6 +260,10 @@ describe('TerminalAddonManager', () => {
                 switch (prop) {
                   case 'width': return `${parentWidth}px`;
                   case 'height': return `${parentHeight}px`;
+                  case 'padding-left': return `${parentPaddingLeft}px`;
+                  case 'padding-right': return `${parentPaddingRight}px`;
+                  case 'padding-top': return `${parentPaddingTop}px`;
+                  case 'padding-bottom': return `${parentPaddingBottom}px`;
                   default: return '0px';
                 }
               }
@@ -419,6 +427,16 @@ describe('TerminalAddonManager', () => {
 
         // Expected: (800 - 4 - 4 - 14) / 10 = 77.8 → 77 cols
         expect(dims.cols).toBe(77);
+      });
+
+      it('should include parent padding in width calculation', async () => {
+        const { terminalMock } = setupProposeDimensionsTest(800, 600, 10, 20, 0, 0, 0, 0, 0, 4, 4, 0, 0);
+
+        const addons = await manager.loadAllAddons(terminalMock as any, 't1', {});
+        const dims = addons.fitAddon.proposeDimensions();
+
+        // Expected: (800 - 4 - 4) / 10 = 79.2 → 79 cols
+        expect(dims.cols).toBe(79);
       });
 
       it('should enforce minimum cols of 2', async () => {

--- a/src/webview/managers/TerminalAddonManager.ts
+++ b/src/webview/managers/TerminalAddonManager.ts
@@ -266,6 +266,12 @@ export class TerminalAddonManager {
       const paddingHorizontal =
         (parseInt(elementStyle.getPropertyValue('padding-left'), 10) || 0) +
         (parseInt(elementStyle.getPropertyValue('padding-right'), 10) || 0);
+      const parentPaddingVertical =
+        (parseInt(parentStyle.getPropertyValue('padding-top'), 10) || 0) +
+        (parseInt(parentStyle.getPropertyValue('padding-bottom'), 10) || 0);
+      const parentPaddingHorizontal =
+        (parseInt(parentStyle.getPropertyValue('padding-left'), 10) || 0) +
+        (parseInt(parentStyle.getPropertyValue('padding-right'), 10) || 0);
 
       const viewport = element.querySelector('.xterm-viewport') as HTMLElement | null;
       const actualScrollbarWidth = viewport
@@ -274,8 +280,8 @@ export class TerminalAddonManager {
       const scrollbarWidth =
         actualScrollbarWidth || core?.viewport?.scrollBarWidth || 0;
 
-      const availableHeight = height - paddingVertical;
-      const availableWidth = width - paddingHorizontal - scrollbarWidth;
+      const availableHeight = height - paddingVertical - parentPaddingVertical;
+      const availableWidth = width - paddingHorizontal - parentPaddingHorizontal - scrollbarWidth;
       const safetyPaddingPx = 0;  // Remove safety padding to maximize visible area
 
       return {


### PR DESCRIPTION
- Change: account for parent padding in FitAddon size calculation to prevent right-edge clipping\n- Impact: WebView terminal rendering\n- Tests: npm run test:unit