### PR TITLE
fix: Migrate to official node-pty for Node.js 22 compatibility (#393)

### DIFF
--- a/.github/workflows/build-platform-packages.yml
+++ b/.github/workflows/build-platform-packages.yml
@@ -94,17 +94,8 @@ jobs:
           - os: ubuntu-latest
             target: linux-arm64
             npm_config_cache: ~/.npm
-          - os: ubuntu-latest
-            target: linux-armhf
-            npm_config_cache: ~/.npm
-
-          # Alpine
-          - os: ubuntu-latest
-            target: alpine-x64
-            npm_config_cache: ~/.npm
-          - os: ubuntu-latest
-            target: alpine-arm64
-            npm_config_cache: ~/.npm
+          # Note: linux-armhf and alpine-* targets removed due to node-pty prebuilt binary limitations
+          # See: https://github.com/s-hiraoku/vscode-sidebar-terminal/issues/393
 
     steps:
       - name: Checkout code

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,28 +12,11 @@ src/**
 # Development and build tools
 node_modules/**
 # Include essential node-pty directories
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/package.json
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/LICENSE
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/typings/**
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/build/Release/**
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/prebuilds/**
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/third_party/**
-# Include only required lib files (exclude tests and maps)
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/index.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/terminal.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/unixTerminal.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/windowsTerminal.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/windowsPtyAgent.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/windowsConoutConnection.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/conpty_console_list_agent.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/eventEmitter2.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/interfaces.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/types.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/utils.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/prebuild-loader.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/prebuild-file-path.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/shared/conout.js
-!node_modules/@homebridge/node-pty-prebuilt-multiarch/lib/worker/conoutSocketWorker.js
+!node_modules/node-pty/package.json
+!node_modules/node-pty/LICENSE
+!node_modules/node-pty/typings/**
+!node_modules/node-pty/prebuilds/**
+!node_modules/node-pty/lib/**
 webpack.config.js
 .gitignore
 .yarnrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added missing ScrollbackManager to WebView manager documentation
   - Expanded File Structure to list all managers explicitly
 
+## [0.2.8] - 2026-01-24
+
+### Fixed
+
+- **Node.js 22 Compatibility**: Fixed extension failing to load on VS Code 1.108+ which uses Node.js 22 (#393)
+  - Migrated from `@homebridge/node-pty-prebuilt-multiarch` to official `node-pty@1.2.0-beta.8`
+  - Official node-pty package includes prebuilt binaries for Node.js 22
+  - Resolves "Cannot find module '../build/Debug/pty.node'" error on Fedora 43 and similar systems
+
+### Changed
+
+- **Platform Support**: Updated supported build targets
+  - Supported: Windows (x64, arm64), macOS (x64, arm64), Linux (x64, arm64)
+  - Removed: Alpine Linux (x64, arm64), Linux armhf due to node-pty prebuilt binary limitations
+
 ## [0.2.7] - 2026-01-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ npm run lint          # ESLint check
 ## Known Limitations
 
 - **Running Processes**: Long-running processes terminate on VS Code restart (scrollback preserved). Use `tmux`/`screen` for process persistence.
+- **Platform Support**: Alpine Linux and Linux armhf are not supported due to node-pty prebuilt binary limitations
 - **Active Development**: Some features may have rough edges
 
 ## Privacy

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,10 @@
       "name": "vscode-sidebar-terminal",
       "version": "0.2.7",
       "bundleDependencies": [
-        "@homebridge/node-pty-prebuilt-multiarch"
+        "node-pty"
       ],
       "license": "MIT",
       "dependencies": {
-        "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-serialize": "^0.14.0",
@@ -20,6 +19,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
+        "node-pty": "^1.2.0-beta.8",
         "process": "^0.11.10"
       },
       "devDependencies": {
@@ -367,7 +367,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -735,7 +734,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -779,7 +777,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1423,21 +1420,6 @@
         "@shikijs/themes": "^3.17.0",
         "@shikijs/types": "^3.17.0",
         "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "node_modules/@homebridge/node-pty-prebuilt-multiarch": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.13.1.tgz",
-      "integrity": "sha512-ccQ60nMcbEGrQh0U9E6x0ajW9qJNeazpcM/9CH6J8leyNtJgb+gu24WTBAfBUVeO486ZhscnaxLEITI2HXwhow==",
-      "hasInstallScript": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^7.1.0",
-        "prebuild-install": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=18.0.0 <25.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2856,7 +2838,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2935,7 +2916,6 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3060,7 +3040,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -3943,7 +3922,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4011,7 +3989,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4203,6 +4180,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4217,7 +4195,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true
+      "optional": true
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
@@ -4298,7 +4276,8 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -4309,7 +4288,8 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -4384,7 +4364,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4403,6 +4382,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4417,7 +4397,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true,
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -4676,7 +4656,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4791,7 +4770,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "inBundle": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
@@ -5164,7 +5144,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -5179,7 +5160,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5303,7 +5285,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5473,7 +5456,8 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -5654,7 +5638,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5710,7 +5693,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5984,7 +5966,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -6274,7 +6257,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "inBundle": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/fs-extra": {
       "version": "11.3.0",
@@ -6472,7 +6456,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "inBundle": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/glob": {
       "version": "13.0.0",
@@ -6886,6 +6871,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6900,7 +6886,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true
+      "optional": true
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -6997,13 +6983,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "inBundle": true
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "inBundle": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/interpret": {
       "version": "3.1.1",
@@ -8050,7 +8037,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -8077,7 +8065,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "inBundle": true,
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -8107,7 +8095,8 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "inBundle": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/mocha": {
       "version": "11.7.5",
@@ -8270,7 +8259,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "inBundle": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -8288,7 +8278,8 @@
       "version": "3.75.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
       "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -8312,6 +8303,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.2.0-beta.8",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.8.tgz",
+      "integrity": "sha512-2gDjTGB/VaMV8cmFMg0d7IfLcWkxtyekn9VSqpq+tUOiu5+nnLfVXYHZbjZCq1kXhnxbdlBjaKLvvVWIbFkicw==",
+      "hasInstallScript": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
       }
     },
     "node_modules/node-releases": {
@@ -8383,7 +8385,6 @@
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.1.0.tgz",
       "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
         "@istanbuljs/schema": "^0.1.2",
@@ -8657,7 +8658,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -9121,7 +9122,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9218,7 +9218,6 @@
       "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -9282,7 +9281,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9374,7 +9372,8 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -9411,7 +9410,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9491,7 +9489,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -9563,7 +9562,8 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -9609,7 +9609,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9970,6 +9971,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9983,8 +9985,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "inBundle": true
+      ]
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -10126,7 +10127,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "inBundle": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10284,6 +10285,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10298,12 +10300,13 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true
+      "optional": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10318,7 +10321,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true,
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -10523,7 +10526,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -10532,7 +10535,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "inBundle": true
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -10781,7 +10784,8 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
       "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -10793,7 +10797,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -10809,7 +10814,8 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -10840,7 +10846,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
       "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.14.0",
@@ -11208,7 +11213,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "inBundle": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -11275,7 +11281,6 @@
       "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -11312,7 +11317,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11450,7 +11454,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "inBundle": true
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -11517,7 +11521,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11593,7 +11596,6 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",
@@ -11769,7 +11771,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -11818,7 +11819,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -12083,7 +12083,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "inBundle": true
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -1064,11 +1064,8 @@
     "vsce:package:win32-arm64": "@vscode/vsce package --target win32-arm64",
     "vsce:package:linux-x64": "@vscode/vsce package --target linux-x64",
     "vsce:package:linux-arm64": "@vscode/vsce package --target linux-arm64",
-    "vsce:package:linux-armhf": "@vscode/vsce package --target linux-armhf",
     "vsce:package:darwin-x64": "@vscode/vsce package --target darwin-x64",
     "vsce:package:darwin-arm64": "@vscode/vsce package --target darwin-arm64",
-    "vsce:package:alpine-x64": "@vscode/vsce package --target alpine-x64",
-    "vsce:package:alpine-arm64": "@vscode/vsce package --target alpine-arm64",
     "create-icons": "node scripts/create-icon.js",
     "pre-release:check": "npm run tdd:comprehensive-check && node scripts/pre-release-hook.js",
     "release:patch": "npm run pre-release:check && npm version patch && git push origin --follow-tags",
@@ -1101,7 +1098,7 @@
     "docs:generate": "npx typedoc",
     "docs:watch": "npx typedoc --watch",
     "docs:clean": "rm -rf docs/api",
-    "rebuild:fast": "npm rebuild @homebridge/node-pty-prebuilt-multiarch"
+    "rebuild:fast": "npm rebuild node-pty"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.0",
@@ -1155,7 +1152,7 @@
     "webpack-cli": "^6.0.0"
   },
   "dependencies": {
-    "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
+    "node-pty": "^1.2.0-beta.8",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",
@@ -1166,10 +1163,10 @@
     "process": "^0.11.10"
   },
   "bundledDependencies": [
-    "@homebridge/node-pty-prebuilt-multiarch"
+    "node-pty"
   ],
   "bundleDependencies": [
-    "@homebridge/node-pty-prebuilt-multiarch"
+    "node-pty"
   ],
   "volta": {
     "node": "24.13.0"

--- a/src/services/TerminalProcessManager.ts
+++ b/src/services/TerminalProcessManager.ts
@@ -1,4 +1,4 @@
-import * as pty from '@homebridge/node-pty-prebuilt-multiarch';
+import * as pty from 'node-pty';
 import { TerminalInstance } from '../types/shared';
 import { OperationResult, OperationResultHandler } from '../utils/OperationResultHandler';
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1,4 +1,4 @@
-import * as pty from '@homebridge/node-pty-prebuilt-multiarch';
+import * as pty from 'node-pty';
 import { TerminalInstance } from '../../types/shared';
 import { terminal as log } from '../../utils/logger';
 import {

--- a/src/services/terminal/TerminalLifecycleService.ts
+++ b/src/services/terminal/TerminalLifecycleService.ts
@@ -1,4 +1,4 @@
-import * as pty from '@homebridge/node-pty-prebuilt-multiarch';
+import * as pty from 'node-pty';
 import {
   TerminalInstance,
   Result,

--- a/src/terminals/TerminalProcessCoordinator.ts
+++ b/src/terminals/TerminalProcessCoordinator.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { TerminalInstance, ProcessState } from '../types/shared';
 import { showWarningMessage } from '../utils/common';
 import { ShellIntegrationService } from '../services/ShellIntegrationService';
-import type { IDisposable } from '@homebridge/node-pty-prebuilt-multiarch';
+import type { IDisposable } from 'node-pty';
 
 /** Manages PTY process lifecycle and shell integration */
 export class TerminalProcessCoordinator {

--- a/src/terminals/TerminalSpawner.ts
+++ b/src/terminals/TerminalSpawner.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as pty from '@homebridge/node-pty-prebuilt-multiarch';
+import * as pty from 'node-pty';
 import { TERMINAL_CONSTANTS } from '../constants';
 import { terminal as log } from '../utils/logger';
 

--- a/src/test/mocks/node-pty.ts
+++ b/src/test/mocks/node-pty.ts
@@ -2,7 +2,7 @@
  * Mock implementation of node-pty for testing environments
  */
 
-import type { IPty, IEvent, IDisposable } from '@homebridge/node-pty-prebuilt-multiarch';
+import type { IPty, IEvent, IDisposable } from 'node-pty';
 
 export type { IPty };
 

--- a/src/test/shared/TestSetup.ts
+++ b/src/test/shared/TestSetup.ts
@@ -336,7 +336,7 @@ export async function setupTestEnvironment(): Promise<void> {
   };
 
   // Register node-pty mocks in cache
-  const ptyModules = ['node-pty', '@homebridge/node-pty-prebuilt-multiarch'];
+  const ptyModules = ['node-pty'];
   ptyModules.forEach((moduleName) => {
     try {
       const modulePath = require.resolve(moduleName, { paths: [process.cwd()] });
@@ -1058,7 +1058,7 @@ export function teardownTestEnvironment(): void {
 
   // Clear require.cache entries we added
   try {
-    const modulesToClear = ['vscode', 'node-pty', '@homebridge/node-pty-prebuilt-multiarch'];
+    const modulesToClear = ['vscode', 'node-pty'];
     modulesToClear.forEach(moduleName => {
       try {
         const modulePath = require.resolve(moduleName, { paths: [process.cwd()] });
@@ -1220,7 +1220,7 @@ export function setupTestEnvironmentSync(): void {
 
   // Register node-pty mock in cache
   try {
-    const ptyPath = require.resolve('@homebridge/node-pty-prebuilt-multiarch', { paths: [process.cwd()] });
+    const ptyPath = require.resolve('node-pty', { paths: [process.cwd()] });
     require.cache[ptyPath] = {
       id: ptyPath,
       filename: ptyPath,

--- a/src/test/vitest/unit/services/terminal/TerminalLifecycleService.test.ts
+++ b/src/test/vitest/unit/services/terminal/TerminalLifecycleService.test.ts
@@ -16,11 +16,11 @@ vi.mock('../../../../../utils/common', () => ({
   },
 }));
 
-import * as pty from '@homebridge/node-pty-prebuilt-multiarch';
+import * as pty from 'node-pty';
 import { TerminalLifecycleService } from '../../../../../services/terminal/TerminalLifecycleService';
 
 // Mock other dependencies
-vi.mock('@homebridge/node-pty-prebuilt-multiarch', () => ({
+vi.mock('node-pty', () => ({
   spawn: vi.fn(),
 }));
 

--- a/src/test/vitest/unit/terminals/CliAgentDetection.test.ts
+++ b/src/test/vitest/unit/terminals/CliAgentDetection.test.ts
@@ -109,7 +109,7 @@ describe.skip('CliAgentDetection in Terminal Manager', () => {
     require.cache[require.resolve('vscode')] = { exports: mockVscode } as any;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-    require.cache[require.resolve('@homebridge/node-pty-prebuilt-multiarch')] = {
+    require.cache[require.resolve('node-pty')] = {
       exports: mockPty,
     } as any;
 

--- a/src/test/vitest/unit/terminals/TerminalSpawner.test.ts
+++ b/src/test/vitest/unit/terminals/TerminalSpawner.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
-import * as pty from '@homebridge/node-pty-prebuilt-multiarch';
+import * as pty from 'node-pty';
 import { TerminalSpawner, TerminalSpawnRequest } from '../../../../terminals/TerminalSpawner';
 import { TERMINAL_CONSTANTS } from '../../../../constants';
 
@@ -14,7 +14,7 @@ vi.mock('fs', () => ({
   },
 }));
 
-vi.mock('@homebridge/node-pty-prebuilt-multiarch', () => ({
+vi.mock('node-pty', () => ({
   spawn: vi.fn(),
 }));
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -21,5 +21,5 @@ export {
   VsCodeMessage,
 } from './shared';
 
-// IPty interface is now defined in node-pty.d.ts for @homebridge/node-pty-prebuilt-multiarch
+// IPty interface is now defined in node-pty.d.ts for node-pty
 // Import IPty from the node-pty module when needed

--- a/src/types/node-pty.d.ts
+++ b/src/types/node-pty.d.ts
@@ -1,47 +1,20 @@
 /**
  * Type definitions for node-pty
- * Provides minimal type definitions for node-pty compatibility
+ *
+ * The official node-pty package includes its own type definitions.
+ * This file is kept for reference and backward compatibility.
+ *
+ * The types are exported from 'node-pty' module directly:
+ * - IPty: Interface representing a pseudoterminal
+ * - IPtyForkOptions: Options for Unix systems
+ * - IWindowsPtyForkOptions: Options for Windows systems
+ * - IDisposable: Object that can be disposed
+ * - IEvent: Event listener interface
+ *
+ * Usage:
+ *   import * as pty from 'node-pty';
+ *   import type { IPty, IDisposable } from 'node-pty';
  */
 
-declare module '@homebridge/node-pty-prebuilt-multiarch' {
-  export interface IPty {
-    pid: number;
-    cols: number;
-    rows: number;
-    handleFlowControl?: boolean;
-    onData: (callback: (data: string) => void) => void;
-    onExit: (callback: (event: number | { exitCode: number; signal?: number }) => void) => void;
-    write: (data: string) => void;
-    resize: (cols: number, rows: number) => void;
-    kill: (signal?: string) => void;
-    clear?: () => void;
-  }
-
-  export interface IWindowsPtyForkOptions {
-    name?: string;
-    cols?: number;
-    rows?: number;
-    cwd?: string;
-    env?: { [key: string]: string };
-    encoding?: string;
-    useConpty?: boolean;
-    conptyInheritCursor?: boolean;
-  }
-
-  export interface IUnixForkOptions {
-    name?: string;
-    cols?: number;
-    rows?: number;
-    cwd?: string;
-    env?: { [key: string]: string };
-    encoding?: string;
-    uid?: number;
-    gid?: number;
-  }
-
-  export function spawn(
-    file?: string,
-    args?: string[] | string,
-    options?: IWindowsPtyForkOptions | IUnixForkOptions
-  ): IPty;
-}
+// Re-export from node-pty for convenience
+export type { IPty, IDisposable, IEvent, IPtyForkOptions, IWindowsPtyForkOptions } from 'node-pty';

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -459,8 +459,8 @@ export interface DeleteResult {
  */
 export interface TerminalInstance {
   id: string;
-  pty?: import('@homebridge/node-pty-prebuilt-multiarch').IPty; // Properly typed node-pty interface
-  ptyProcess?: import('@homebridge/node-pty-prebuilt-multiarch').IPty; // New pty reference name (for session restoration)
+  pty?: import('node-pty').IPty; // Properly typed node-pty interface
+  ptyProcess?: import('node-pty').IPty; // New pty reference name (for session restoration)
   process?: NodeJS.Process; // For lifecycle service compatibility
   name: string;
   number?: number; // Terminal number (1-5)

--- a/src/types/type-guards.ts
+++ b/src/types/type-guards.ts
@@ -84,7 +84,7 @@ export type MessageHandler<T extends WebviewMessage = WebviewMessage> = (
 /**
  * Node-pty compatible process type
  */
-export type PtyProcess = import('@homebridge/node-pty-prebuilt-multiarch').IPty;
+export type PtyProcess = import('node-pty').IPty;
 
 /**
  * Node.js process reference

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -59,10 +59,6 @@ export default defineConfig({
       vscode: path.resolve(__dirname, 'src/test/vitest/mocks/vscode.ts'),
       // Mock node-pty
       'node-pty': path.resolve(__dirname, 'src/test/vitest/mocks/node-pty.ts'),
-      '@homebridge/node-pty-prebuilt-multiarch': path.resolve(
-        __dirname,
-        'src/test/vitest/mocks/node-pty.ts'
-      ),
     },
   },
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,8 +47,8 @@ const extensionConfig = {
   },
   externals: {
     vscode: 'commonjs vscode',
-    // Keep @homebridge/node-pty-prebuilt-multiarch as external since it's included in the package
-    '@homebridge/node-pty-prebuilt-multiarch': 'commonjs @homebridge/node-pty-prebuilt-multiarch',
+    // Keep node-pty as external since it's included in the package
+    'node-pty': 'commonjs node-pty',
   },
   optimization: {
     minimize: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
## Summary

- Migrate from `@homebridge/node-pty-prebuilt-multiarch` to official `node-pty@1.2.0-beta.8`
- Fix extension failing to load on VS Code 1.108+ which uses Node.js 22
- Resolves "Cannot find module '../build/Debug/pty.node'" error on Fedora 43 and similar systems

## Changes

### Package Migration
- Updated `package.json` dependency from `@homebridge/node-pty-prebuilt-multiarch@^0.13.1` to `node-pty@^1.2.0-beta.8`
- Updated `bundledDependencies` to use `node-pty`
- Updated `.vscodeignore` for new package structure

### Source Code Updates
- Updated all imports from `@homebridge/node-pty-prebuilt-multiarch` to `node-pty`
- Updated type definitions in `src/types/node-pty.d.ts`
- Updated webpack externals configuration

### Build Configuration
- Removed unsupported platform targets from GitHub Actions workflow:
  - `alpine-x64`, `alpine-arm64`, `linux-armhf`
- These platforms are not supported by official node-pty prebuilt binaries

### Documentation
- Updated CHANGELOG.md with v0.2.8 release notes
- Updated README.md Known Limitations section

## Platform Support

| Platform | Status |
|----------|--------|
| Windows x64/arm64 | ✅ Supported |
| macOS x64/arm64 | ✅ Supported |
| Linux x64/arm64 | ✅ Supported |
| Alpine Linux | ❌ Removed |
| Linux armhf | ❌ Removed |

## Test Plan

- [x] `npm install` succeeds
- [x] `npm run compile` succeeds
- [x] `npm test` passes (207 passed, 1 skipped)
- [x] `npm run lint` passes (0 errors, 323 warnings)
- [x] `npm run pre-release:check` passes

Fixes #393

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>