### PR TITLE
docs: align release docs with main workflow

### DIFF
--- a/docs/operations/EMERGENCY_ROLLBACK.md
+++ b/docs/operations/EMERGENCY_ROLLBACK.md
@@ -107,7 +107,7 @@ npm run tdd:comprehensive-check
 
 ```bash
 # 修正版のパッチリリース
-npm run release:patch:safe
+npm run release:patch
 ```
 
 ## 📞 緊急連絡先・エスカレーション

--- a/docs/operations/releases/RELEASE_COMMANDS.md
+++ b/docs/operations/releases/RELEASE_COMMANDS.md
@@ -1,150 +1,44 @@
-# Quality-Assured Release Commands
+# Release Commands
 
-VS Code拡張の品質を保証したリリースを自動化するカスタムコマンドです。
+VS Code Sidebar Terminal のリリースは `main` ブランチから `npm run release:*` を実行します。
 
-## 🚀 スラッシュコマンド
+## ✅ 事前チェック
 
-Claude Codeで以下のスラッシュコマンドが使用できます：
-
-### `/release [patch|minor|major]`
-**完全自動品質チェック＆リリース**
-
-```bash
-/release patch    # パッチバージョンリリース (0.1.70 → 0.1.71)
-/release minor    # マイナーバージョンリリース (0.1.70 → 0.2.0)  
-/release major    # メジャーバージョンリリース (0.1.70 → 1.0.0)
-```
-
-**実行内容**:
-1. 🔍 **品質チェック** - TypeScript、ESLint、ビルド、テスト、Git状態
-2. 🔧 **自動修正** - 検出されたエラーの自動修正
-3. 📦 **バージョン管理** - package.jsonバージョン更新とGitタグ作成
-4. 🚀 **自動デプロイ** - GitHubプッシュとActions実行
-
-### `/quality`
-**品質チェックのみ実行**
+- `main` が最新
+- 未コミット変更がない
+- 必要なテストが通っている
 
 ```bash
-/quality    # リリースせずに品質レポートのみ生成
+git checkout main
+git pull origin main
+
+git status -sb
+npm run test
+npm run lint
 ```
 
-### `/fix` 
-**自動修正のみ実行**
+## 🚀 リリース実行
 
 ```bash
-/fix    # エラーの自動修正のみ実行
+# パッチリリース (0.1.70 → 0.1.71)
+npm run release:patch
+
+# マイナーリリース (0.1.70 → 0.2.0)
+npm run release:minor
+
+# メジャーリリース (0.1.70 → 1.0.0)
+npm run release:major
 ```
 
-## 📋 NPMスクリプト
+## 🔍 実行される処理
 
-```bash
-# 完全リリース
-npm run release:patch:safe     # パッチリリース
-npm run release:minor:safe     # マイナーリリース  
-npm run release:major:safe     # メジャーリリース
+- 事前チェック (`npm run pre-release:check`) を実行
+- `package.json` のバージョン更新
+- Git タグ作成
+- タグを含めて `origin` に push
 
-# 品質チェックのみ
-npm run quality:check          # 品質レポート生成
+GitHub Actions がタグを検知してビルド・リリースを進めます。
 
-# 自動修正のみ  
-npm run quality:fix            # エラー自動修正
-```
+## 🛠️ うまくいかない場合
 
-## 🔍 品質チェック項目
-
-| チェック項目 | 説明 | 自動修正 |
-|-------------|------|----------|
-| **Dependencies** | package-lock.json存在確認 | ✅ `npm install` |
-| **TypeScript** | 型エラー・コンパイルエラー | ✅ 一般的パターン修正 |
-| **ESLint** | コード品質・スタイル | ✅ `--fix`オプション |
-| **Build** | webpack ビルド成功 | ❌ 手動確認必要 |
-| **Tests** | テストコンパイル | ❌ 手動修正必要 |
-| **Git Status** | 未コミット変更確認 | ❌ 手動確認必要 |
-
-## 🔧 自動修正機能
-
-### TypeScriptエラー自動修正
-- `bellStyle`プロパティエラー → コメントアウト
-- `string | null` vs `string | undefined` → 型変換
-- 一般的なインターフェース不一致 → 修正提案
-
-### ESLintエラー自動修正  
-- コードフォーマット
-- 未使用変数削除
-- インポート整理
-
-### 依存関係自動修正
-- `package-lock.json` 再生成
-- `node_modules` インストール
-
-## 🛡️ 品質保証レベル
-
-**Zero-Error Release**: エラーが1つでもある場合はリリースを停止
-
-- ✅ TypeScriptコンパイルエラー: **0個必須**
-- ✅ ESLintエラー: **0個必須** (警告は許可)
-- ✅ ビルドエラー: **0個必須**
-- ✅ Git未コミット変更: **0個必須**
-
-## 📊 出力例
-
-### 成功時
-```
-🎉 RELEASE COMPLETED SUCCESSFULLY!
-
-📦 Version: v0.1.71
-🔧 Auto-fixes applied: 2
-⚠️  Warnings: 12
-
-🚀 GitHub Actions will now build and deploy to:
-   - VS Code Marketplace (all platforms)
-   - GitHub Releases
-```
-
-### エラー時
-```  
-❌ Quality gate failed with 3 errors
-
-📋 ERROR SUMMARY:
-1. TypeScript: Property 'bellStyle' does not exist
-2. ESLint: 5 errors found  
-3. Git Status: 2 uncommitted files
-
-🔧 Attempting automatic fixes...
-✅ Fixed: TypeScript
-✅ Fixed: ESLint  
-❌ Cannot auto-fix: Git Status (manual intervention required)
-```
-
-## 🎯 使用例
-
-### 通常のパッチリリース
-```bash
-/release patch
-```
-
-### リリース前の品質確認
-```bash
-/quality
-# 問題があれば修正
-/fix
-# 再確認後リリース
-/release patch
-```
-
-### 手動品質管理
-```bash
-npm run quality:check     # 品質レポート確認
-npm run quality:fix       # 自動修正実行
-npm run quality:check     # 修正結果確認
-npm run release:patch:safe  # リリース実行
-```
-
-## ⚠️ 注意事項
-
-1. **Git状態**: 未コミットの変更がある場合はリリースできません
-2. **手動修正**: すべてのエラーが自動修正できるわけではありません
-3. **テスト実行**: フルテストは時間がかかるため、コンパイルチェックのみ実行
-4. **バックアップ**: 重要な変更前にはブランチ作成を推奨
-
-このコマンドにより、品質問題による本番リリース失敗を完全に防止できます。
+自動化が失敗した場合は、`docs/operations/RELEASE_PROCESS.md` の手動手順に従ってください。

--- a/src/test/vitest/unit/docs/ReleaseDocs.test.ts
+++ b/src/test/vitest/unit/docs/ReleaseDocs.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../..');
+
+const readDoc = (relativePath: string): string =>
+  fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+describe('Release documentation', () => {
+  it('documents main as the release branch', () => {
+    const content = readDoc('docs/operations/RELEASE_PROCESS.md');
+
+    expect(content).toContain('git checkout main');
+    expect(content).not.toContain('for-publish');
+  });
+
+  it('uses supported release scripts instead of deprecated slash commands', () => {
+    const content = readDoc('docs/operations/releases/RELEASE_COMMANDS.md');
+
+    expect(content).toContain('npm run release:patch');
+    expect(content).toContain('npm run release:minor');
+    expect(content).toContain('npm run release:major');
+
+    expect(content).not.toMatch(/^\/release\s+/m);
+    expect(content).not.toMatch(/^\/quality\b/m);
+    expect(content).not.toMatch(/^\/fix\b/m);
+    expect(content).not.toMatch(/release:(patch|minor|major):safe/);
+    expect(content).not.toMatch(/quality:(check|fix)/);
+  });
+
+  it('avoids deprecated safe release scripts in emergency rollback guidance', () => {
+    const content = readDoc('docs/operations/EMERGENCY_ROLLBACK.md');
+
+    expect(content).toContain('npm run release:patch');
+    expect(content).not.toMatch(/release:patch:safe/);
+  });
+});


### PR DESCRIPTION
## Summary
- align release docs with main-based workflow
- remove deprecated slash/safe/quality release commands
- add docs tests to prevent regressions

## Testing
- npx vitest run src/test/vitest/unit/docs/ReleaseDocs.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified release commands documentation with a streamlined workflow, removing granular release options.
  * Updated emergency rollback procedures with corrected script references.

* **Tests**
  * Added automated tests to validate release documentation consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->