### PR TITLE
fix: detect GitHub Copilot startup banner without CLI suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **GitHub Copilot Startup Detection**: Fixed detection failure when Copilot displays version banner (`GitHub Copilot v0.0.406`) instead of legacy `GitHub Copilot CLI` text
+  - Updated startup regex pattern from `/GitHub\s+Copilot\s+CLI/i` to `/GitHub\s+Copilot/i`
+  - Now correctly detects both old (`GitHub Copilot CLI`) and new (`GitHub Copilot vX.X.X`) startup banners
+
 ## [0.2.15] - 2026-02-08
 
 ### Fixed

--- a/src/services/CliAgentPatternRegistry.ts
+++ b/src/services/CliAgentPatternRegistry.ts
@@ -141,7 +141,7 @@ export class CliAgentPatternRegistry {
       type: 'copilot',
       commandPrefixes: ['copilot ', 'copilot', 'gh copilot'],
       startupPatterns: ['Welcome to GitHub Copilot CLI'],
-      startupRegexPatterns: [/GitHub\s+Copilot\s+CLI/i],
+      startupRegexPatterns: [/GitHub\s+Copilot/i],
       activityKeywords: ['copilot', 'github'],
       terminationPatterns: [],
       terminationRegexPatterns: [/\[process exited with code \d+\]/i],

--- a/src/test/vitest/unit/services/CliAgentPatternRegistry.test.ts
+++ b/src/test/vitest/unit/services/CliAgentPatternRegistry.test.ts
@@ -50,6 +50,15 @@ describe('CliAgentPatternRegistry', () => {
       expect(registry.matchStartupOutput('Gemini model initialized')).toBe('gemini');
     });
 
+    it('should match GitHub Copilot startup banner with version', () => {
+      expect(registry.matchStartupOutput('GitHub Copilot v0.0.406')).toBe('copilot');
+      expect(registry.matchStartupOutput('GitHub Copilot v1.2.3')).toBe('copilot');
+    });
+
+    it('should match GitHub Copilot CLI startup message', () => {
+      expect(registry.matchStartupOutput('Welcome to GitHub Copilot CLI')).toBe('copilot');
+    });
+
     it('should not match plain agent command text as startup output', () => {
       expect(registry.matchStartupOutput('opencode')).toBeNull();
       expect(registry.matchStartupOutput('copilot')).toBeNull();


### PR DESCRIPTION
## Summary

- GitHub Copilot CLI now displays `GitHub Copilot v0.0.406` on startup instead of `GitHub Copilot CLI`, causing agent detection to fail
- Broadened startup regex from `/GitHub\s+Copilot\s+CLI/i` to `/GitHub\s+Copilot/i` to match both old and new banners
- Added tests for version-based startup banner detection

## Test plan

- [x] Added test: `should match GitHub Copilot startup banner with version` (`v0.0.406`, `v1.2.3`)
- [x] Added test: `should match GitHub Copilot CLI startup message` (backward compat)
- [x] All 46 pattern registry tests pass
- [x] All 140 CLI agent tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GitHub Copilot startup detection to recognize both legacy CLI banners and newer version banners (e.g., GitHub Copilot v1.2.3). This improves compatibility across different Copilot installation types and versions.

* **Tests**
  * Added tests to verify startup detection correctly identifies all supported GitHub Copilot banner formats and welcome messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->