### PR TITLE
fix: prevent secondary sidebar maximize from being cancelled

### DIFF
--- a/src/providers/SecondaryTerminalProvider.ts
+++ b/src/providers/SecondaryTerminalProvider.ts
@@ -62,6 +62,7 @@ export class SecondaryTerminalProvider implements vscode.WebviewViewProvider, vs
   private _webviewMessageListenerDisposable: vscode.Disposable | null = null;
   private _webviewMessageListenerView: vscode.WebviewView | null = null;
   private _pendingPanelMoveReinit = false;
+  private _hasDetectedPanelLocation = false;
 
   // Phase 8 services (typed properly)
   private _decorationsService?: import('../services/TerminalDecorationsService').TerminalDecorationsService;
@@ -419,10 +420,19 @@ export class SecondaryTerminalProvider implements vscode.WebviewViewProvider, vs
   private _handleWebviewVisible(): void {
     log('🔄 [VISIBILITY] Handling WebView visible event');
 
-    // Trigger panel location detection with debounce
+    // Guard: Skip panel location detection on simple visibility restore.
+    // Only detect on first visibility to prevent unnecessary setContext calls
+    // that can cancel VS Code's secondary sidebar maximize state.
+    if (this._hasDetectedPanelLocation) {
+      log('⏭️ [VISIBILITY] Panel location already detected, skipping redundant detection');
+      return;
+    }
+
+    // First visibility: trigger detection
     setTimeout(() => {
-      log('📍 [VISIBILITY] Requesting panel location detection after visibility change');
+      log('📍 [VISIBILITY] Requesting initial panel location detection');
       this._requestPanelLocationDetection();
+      this._hasDetectedPanelLocation = true;
     }, 200);
   }
 
@@ -1642,6 +1652,7 @@ export class SecondaryTerminalProvider implements vscode.WebviewViewProvider, vs
 
     // Reset state
     this._isInitialized = false;
+    this._hasDetectedPanelLocation = false;
 
     log('✅ [DEBUG] SecondaryTerminalProvider disposed');
   }

--- a/src/providers/services/PanelLocationService.ts
+++ b/src/providers/services/PanelLocationService.ts
@@ -130,19 +130,20 @@ export class PanelLocationService implements vscode.Disposable {
     this._cachedPanelLocation = location;
     log('📍 [DEBUG] ✅ Cached panel location UPDATED:', location);
 
-    // Update context key for VS Code when clause
-    await vscode.commands.executeCommand('setContext', PanelLocationService.CONTEXT_KEY, location);
-    log('📍 [DEBUG] Context key updated with panel location:', location);
+    // Only call setContext when location actually changes.
+    // Redundant setContext calls trigger VS Code layout recalculation,
+    // which can cancel the secondary sidebar's maximized state.
+    if (previousLocation !== location) {
+      await vscode.commands.executeCommand('setContext', PanelLocationService.CONTEXT_KEY, location);
+      log('📍 [DEBUG] Context key updated with NEW panel location:', location);
 
-    // 🎯 REMOVED: No longer send confirmation back to WebView
-    // WebView applies changes autonomously, reducing message round-trips
-    // await this._sendMessage({ command: 'panelLocationUpdate', location: location });
-    log('📍 [DEBUG] ✅ Location cached and context updated (no confirmation message sent)');
-
-    // Notify caller if location changed
-    if (previousLocation !== location && onLocationChange) {
-      log(`🔄 [RELAYOUT] Location changed: ${previousLocation} → ${location}`);
-      await onLocationChange(previousLocation, location);
+      // Notify caller if location changed
+      if (onLocationChange) {
+        log(`🔄 [RELAYOUT] Location changed: ${previousLocation} → ${location}`);
+        await onLocationChange(previousLocation, location);
+      }
+    } else {
+      log('📍 [DEBUG] ⏭️ Panel location unchanged, skipping setContext');
     }
 
     log('📍 [DEBUG] ===============================================================');

--- a/src/test/vitest/unit/providers/SecondaryTerminalProvider-Visibility.test.ts
+++ b/src/test/vitest/unit/providers/SecondaryTerminalProvider-Visibility.test.ts
@@ -1,0 +1,153 @@
+/**
+ * SecondaryTerminalProvider - Visibility Guard Tests
+ *
+ * Fix: Prevent secondary sidebar maximize from being cancelled
+ * when _handleWebviewVisible triggers redundant panel location detection.
+ *
+ * Root cause: _handleWebviewVisible() unconditionally calls _requestPanelLocationDetection()
+ * on every visibility change, even simple focus-driven hidden->visible transitions.
+ * The resulting setContext call triggers VS Code layout recalculation, cancelling maximize.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock VS Code API
+vi.mock('vscode', () => ({
+  commands: {
+    executeCommand: vi.fn().mockResolvedValue(undefined),
+  },
+  workspace: {
+    getConfiguration: vi.fn(() => ({
+      get: vi.fn((key: string, def: unknown) => def),
+    })),
+    onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+  },
+  window: {
+    activeColorTheme: { kind: 2 },
+  },
+  ColorThemeKind: {
+    Light: 1,
+    Dark: 2,
+    HighContrast: 3,
+    HighContrastLight: 4,
+  },
+}));
+
+// Mock logger
+vi.mock('../../../../../utils/logger', () => ({
+  provider: vi.fn(),
+  isDebugEnabled: vi.fn(() => false),
+}));
+
+describe('SecondaryTerminalProvider - Visibility Guard', () => {
+  let mockRequestPanelLocationDetection: ReturnType<typeof vi.fn>;
+  let provider: {
+    _hasDetectedPanelLocation: boolean;
+    _handleWebviewVisible: () => void;
+    _requestPanelLocationDetection: () => void;
+    dispose: () => void;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockRequestPanelLocationDetection = vi.fn();
+
+    // Create a minimal mock that simulates the fixed SecondaryTerminalProvider behavior
+    provider = {
+      _hasDetectedPanelLocation: false,
+
+      _handleWebviewVisible() {
+        // Guard: Skip panel location detection on simple visibility restore
+        if (this._hasDetectedPanelLocation) {
+          return;
+        }
+
+        // First visibility: trigger detection
+        setTimeout(() => {
+          this._requestPanelLocationDetection();
+          this._hasDetectedPanelLocation = true;
+        }, 200);
+      },
+
+      _requestPanelLocationDetection: mockRequestPanelLocationDetection,
+
+      dispose() {
+        this._hasDetectedPanelLocation = false;
+      },
+    };
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe('_handleWebviewVisible - panel location detection guard', () => {
+    it('should detect panel location on first visibility event', () => {
+      // Act: First visibility event
+      provider._handleWebviewVisible();
+      vi.advanceTimersByTime(200);
+
+      // Assert: Detection should run
+      expect(mockRequestPanelLocationDetection).toHaveBeenCalledTimes(1);
+    });
+
+    it('should set _hasDetectedPanelLocation flag after first detection', () => {
+      // Arrange: Flag starts false
+      expect(provider._hasDetectedPanelLocation).toBe(false);
+
+      // Act: First visibility event
+      provider._handleWebviewVisible();
+      vi.advanceTimersByTime(200);
+
+      // Assert: Flag is now true
+      expect(provider._hasDetectedPanelLocation).toBe(true);
+    });
+
+    it('should skip panel location detection on subsequent visibility restore', () => {
+      // Arrange: Simulate first detection completed
+      provider._handleWebviewVisible();
+      vi.advanceTimersByTime(200);
+      mockRequestPanelLocationDetection.mockClear();
+
+      // Act: Subsequent visibility events (e.g., focus changes during Claude Code operation)
+      provider._handleWebviewVisible();
+      vi.advanceTimersByTime(200);
+
+      provider._handleWebviewVisible();
+      vi.advanceTimersByTime(200);
+
+      // Assert: No additional detection calls
+      expect(mockRequestPanelLocationDetection).not.toHaveBeenCalled();
+    });
+
+    it('should reset flag on dispose (allowing re-detection after reinitialization)', () => {
+      // Arrange: Complete first detection
+      provider._handleWebviewVisible();
+      vi.advanceTimersByTime(200);
+      expect(provider._hasDetectedPanelLocation).toBe(true);
+
+      // Act: Dispose (simulates WebView destruction)
+      provider.dispose();
+
+      // Assert: Flag is reset
+      expect(provider._hasDetectedPanelLocation).toBe(false);
+    });
+
+    it('should allow detection after dispose and re-creation', () => {
+      // Arrange: Complete first detection cycle
+      provider._handleWebviewVisible();
+      vi.advanceTimersByTime(200);
+      mockRequestPanelLocationDetection.mockClear();
+
+      // Act: Dispose and trigger new visibility
+      provider.dispose();
+      provider._handleWebviewVisible();
+      vi.advanceTimersByTime(200);
+
+      // Assert: Detection runs again for new lifecycle
+      expect(mockRequestPanelLocationDetection).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a _hasDetectedPanelLocation guard in SecondaryTerminalProvider to skip redundant visibility-triggered panel detection
- skip setContext in PanelLocationService when reported location is unchanged
- add/extend unit tests for visibility guard behavior and redundant setContext suppression

## Testing
- npx vitest run src/test/vitest/unit/providers/SecondaryTerminalProvider-Visibility.test.ts src/test/vitest/unit/providers/services/PanelLocationService.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant panel location detection on repeated visibility events, eliminating unnecessary context updates and layout recalculations.
  * Updated panel location service to only notify changes when the location actually differs from the previous state, reducing redundant message round-trips.

* **Tests**
  * Added comprehensive unit test coverage for visibility guard behavior and location service redundancy detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->