### PR TITLE
docs(marketplace): point homepage to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 **English** | [日本語](README.ja.md) | [中文](README.zh-CN.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md)
 
+Docs: https://s-hiraoku.github.io/vscode-sidebar-terminal/
+
 Your sidebar, your terminal, your AI agents -- all in one place. A full-featured terminal that lives in the VS Code sidebar, with built-in AI agent detection for Claude Code, Codex CLI, Gemini CLI, GitHub Copilot CLI.
 
 <video src="resources/demo/demo.mov" controls muted loop playsinline poster="resources/readme-hero.png"></video>

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "bugs": {
     "url": "https://github.com/s-hiraoku/vscode-sidebar-terminal/issues"
   },
-  "homepage": "https://github.com/s-hiraoku/vscode-sidebar-terminal#readme",
+  "homepage": "https://s-hiraoku.github.io/vscode-sidebar-terminal/",
   "license": "MIT",
   "qna": "https://github.com/s-hiraoku/vscode-sidebar-terminal/discussions",
   "preview": false,


### PR DESCRIPTION
## Summary
- update the extension homepage metadata to the published GitHub Pages site
- add the docs URL near the top of README so it is visible from Marketplace content

## Why
- surface the published documentation as the primary project homepage
- make the docs entry point easier to discover from the extension listing

## Validation
- `npm run compile`
- `npm run lint` (passes with existing warnings only)
- `npm run test:unit`
