### PR TITLE
fix: prevent toast notifications from stealing terminal focus

### DIFF
--- a/src/services/ToastNotificationService.ts
+++ b/src/services/ToastNotificationService.ts
@@ -3,6 +3,7 @@ import { terminal as log } from '../utils/logger';
 import type { AgentType } from '../types/shared';
 
 const SETTING_PREFIX = 'secondaryTerminal';
+const STATUS_BAR_DISPLAY_MS = 5000;
 
 const AGENT_DISPLAY_NAMES: Record<string, string> = {
   claude: 'Claude',
@@ -67,7 +68,7 @@ export class ToastNotificationService implements vscode.Disposable {
     const message = `CLI Agent is ${typeLabel} (${terminalId})`;
 
     log('[TOAST]', message);
-    vscode.window.showInformationMessage(message);
+    vscode.window.setStatusBarMessage(`$(terminal) ${message}`, STATUS_BAR_DISPLAY_MS);
   }
 
   public showCompletedNotification(
@@ -88,7 +89,7 @@ export class ToastNotificationService implements vscode.Disposable {
     const message = `${agentName} has completed (${terminalId})`;
 
     log('[TOAST]', message);
-    vscode.window.showInformationMessage(message);
+    vscode.window.setStatusBarMessage(`$(terminal) ${message}`, STATUS_BAR_DISPLAY_MS);
   }
 
   public clearTerminal(terminalId: string): void {

--- a/src/test/vitest/unit/services/ToastNotificationService.test.ts
+++ b/src/test/vitest/unit/services/ToastNotificationService.test.ts
@@ -3,6 +3,7 @@ import { ToastNotificationService } from '../../../../services/ToastNotification
 
 const mockGetConfig = vi.fn();
 const mockShowInformationMessage = vi.fn();
+const mockSetStatusBarMessage = vi.fn();
 
 vi.mock('vscode', () => ({
   workspace: {
@@ -10,6 +11,7 @@ vi.mock('vscode', () => ({
   },
   window: {
     showInformationMessage: (...args: any[]) => mockShowInformationMessage(...args),
+    setStatusBarMessage: (...args: any[]) => mockSetStatusBarMessage(...args),
   },
 }));
 
@@ -33,6 +35,7 @@ describe('ToastNotificationService', () => {
     vi.useFakeTimers();
     setDefaultConfig();
     mockShowInformationMessage.mockClear();
+    mockSetStatusBarMessage.mockClear();
     service = new ToastNotificationService();
   });
 
@@ -44,113 +47,135 @@ describe('ToastNotificationService', () => {
   describe('showWaitingNotification', () => {
     it('should show notification when enabled', () => {
       service.showWaitingNotification('terminal-1');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(1);
-      expect(mockShowInformationMessage).toHaveBeenCalledWith(
-        expect.stringContaining('waiting for input')
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(1);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledWith(
+        expect.stringContaining('waiting for input'),
+        expect.any(Number)
       );
     });
 
     it('should not show notification when disabled', () => {
       setDefaultConfig({ 'agentToastNotification.enabled': false });
       service.showWaitingNotification('terminal-1');
-      expect(mockShowInformationMessage).not.toHaveBeenCalled();
+      expect(mockSetStatusBarMessage).not.toHaveBeenCalled();
     });
 
     it('should respect per-terminal cooldown', () => {
       service.showWaitingNotification('terminal-1');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(1);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(1);
 
       service.showWaitingNotification('terminal-1');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(1);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(1);
 
       vi.advanceTimersByTime(10000);
       service.showWaitingNotification('terminal-1');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(2);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(2);
     });
 
     it('should enforce global cooldown across terminals', () => {
       service.showWaitingNotification('terminal-1');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(1);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(1);
 
       service.showWaitingNotification('terminal-2');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(1);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(1);
 
       vi.advanceTimersByTime(10000);
       service.showWaitingNotification('terminal-2');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(2);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(2);
     });
 
     it('should show input-specific message for waitingType=input', () => {
       service.showWaitingNotification('terminal-1', 'input');
-      expect(mockShowInformationMessage).toHaveBeenCalledWith(
-        expect.stringContaining('waiting for input')
+      expect(mockSetStatusBarMessage).toHaveBeenCalledWith(
+        expect.stringContaining('waiting for input'),
+        expect.any(Number)
       );
     });
 
     it('should show approval-specific message for waitingType=approval', () => {
       service.showWaitingNotification('terminal-1', 'approval');
-      expect(mockShowInformationMessage).toHaveBeenCalledWith(
-        expect.stringContaining('waiting for approval')
+      expect(mockSetStatusBarMessage).toHaveBeenCalledWith(
+        expect.stringContaining('waiting for approval'),
+        expect.any(Number)
       );
     });
 
     it('should not show notification after dispose', () => {
       service.dispose();
       service.showWaitingNotification('terminal-1');
-      expect(mockShowInformationMessage).not.toHaveBeenCalled();
+      expect(mockSetStatusBarMessage).not.toHaveBeenCalled();
     });
   });
 
   describe('showCompletedNotification', () => {
     it('should show completion notification', () => {
       service.showCompletedNotification('terminal-1');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(1);
-      expect(mockShowInformationMessage).toHaveBeenCalledWith(
-        expect.stringContaining('completed')
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(1);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledWith(
+        expect.stringContaining('completed'),
+        expect.any(Number)
       );
     });
 
     it('should include agent type in completion message', () => {
       service.showCompletedNotification('terminal-1', 'claude');
-      expect(mockShowInformationMessage).toHaveBeenCalledWith(
-        expect.stringContaining('Claude')
+      expect(mockSetStatusBarMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Claude'),
+        expect.any(Number)
       );
     });
 
     it('should not show when disabled', () => {
       setDefaultConfig({ 'agentToastNotification.enabled': false });
       service.showCompletedNotification('terminal-1');
-      expect(mockShowInformationMessage).not.toHaveBeenCalled();
+      expect(mockSetStatusBarMessage).not.toHaveBeenCalled();
     });
 
     it('should respect cooldown', () => {
       service.showCompletedNotification('terminal-1');
       service.showCompletedNotification('terminal-1');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(1);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(1);
 
       vi.advanceTimersByTime(10000);
       service.showCompletedNotification('terminal-1');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(2);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(2);
     });
 
     it('should not show after dispose', () => {
       service.dispose();
       service.showCompletedNotification('terminal-1');
-      expect(mockShowInformationMessage).not.toHaveBeenCalled();
+      expect(mockSetStatusBarMessage).not.toHaveBeenCalled();
     });
   });
 
   describe('clearTerminal', () => {
     it('should allow notification after clearTerminal resets cooldown', () => {
       service.showWaitingNotification('terminal-1');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(1);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(1);
 
       service.clearTerminal('terminal-1');
 
       // Global cooldown still applies, advance past it
       vi.advanceTimersByTime(10000);
       service.showWaitingNotification('terminal-1');
-      expect(mockShowInformationMessage).toHaveBeenCalledTimes(2);
+      expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('focus safety', () => {
+    it('should never call showInformationMessage to avoid stealing focus', () => {
+      service.showWaitingNotification('terminal-1');
+      vi.advanceTimersByTime(10000);
+      service.showCompletedNotification('terminal-2', 'claude');
+      expect(mockShowInformationMessage).not.toHaveBeenCalled();
+    });
+
+    it('should use setStatusBarMessage with auto-dismiss duration', () => {
+      service.showCompletedNotification('terminal-1', 'claude');
+      expect(mockSetStatusBarMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Claude'),
+        expect.any(Number)
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Replace `vscode.window.showInformationMessage` with `vscode.window.setStatusBarMessage` for agent notifications
- Fixes cursor unexpectedly jumping to VS Code's built-in terminal after AI agent completes processing
- Status bar messages auto-dismiss after 5 seconds without stealing focus

## Root Cause

`showInformationMessage` displays a notification that shifts focus away from the WebView (Secondary Terminal). This happens when:
- An AI agent finishes processing (completion notification)  
- An AI agent is waiting for input (waiting notification)

## Fix

Use `setStatusBarMessage` instead, which displays in the status bar without affecting focus.

## Test plan

- [x] 16 unit tests pass (including 2 new focus safety tests)
- [x] TypeScript compiles without errors
- [x] New test verifies `showInformationMessage` is never called

🤖 Generated with [Claude Code](https://claude.com/claude-code)