### PR TITLE
chore(release): 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the "Secondary Terminal" extension will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [0.3.3](https://github.com/s-hiraoku/vscode-sidebar-terminal/compare/v0.3.1...v0.3.3) (2026-03-24)
+
+
+### Changed
+
+* **marketplace:** point homepage to GitHub Pages ([#538](https://github.com/s-hiraoku/vscode-sidebar-terminal/issues/538)) ([3024283](https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/302428315b38c1ef177a0801601afccd6f974025))
+
+
+### Fixed
+
+* **ci:** use npm install instead of npm ci for docs build ([1344072](https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/13440727d71e37371fe1a3b7bfd465d82cd19d6c))
+* prevent toast notifications from stealing focus away from terminal ([#539](https://github.com/s-hiraoku/vscode-sidebar-terminal/issues/539)) ([eec5507](https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/eec5507c0026bfb6125b7d5af8e572616f4026dd))
+* **webview:** clean up terminal restore teardown ([18ea9cd](https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/18ea9cd7c77f3641b44c8aab696f62379fd67b9b))
+
 ### [0.3.2](https://github.com/s-hiraoku/vscode-sidebar-terminal/compare/v0.3.1...v0.3.2) (2026-03-24)
 
 ### [0.3.1](https://github.com/s-hiraoku/vscode-sidebar-terminal/compare/v0.3.0...v0.3.1) (2026-03-23)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-sidebar-terminal",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-sidebar-terminal",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "bundleDependencies": [
         "node-pty"
       ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sidebar-terminal",
   "displayName": "Secondary Terminal",
   "description": "Production-ready VS Code extension with TypeScript-compliant terminal in sidebar, ProcessState/InteractionState management, and comprehensive session management.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "publisher": "s-hiraoku",
   "sideEffects": false,
   "engines": {


### PR DESCRIPTION
## Release 0.3.3

### Fixed
- Prevent toast notifications from stealing focus away from terminal (#539)
- CI: use npm install instead of npm ci for docs build
- WebView: clean up terminal restore teardown

### Changed
- Marketplace homepage now points to GitHub Pages (#538)

## Checklist
- [x] Version bumped to 0.3.3
- [x] CHANGELOG.md updated
- [ ] CI passes
- [ ] Create tag `v0.3.3` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)