### PR TITLE
fix: aggressive focus protection when CLI agent is connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the "Secondary Terminal" extension will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [0.6.3](https://github.com/s-hiraoku/vscode-sidebar-terminal/compare/v0.6.1...v0.6.3) (2026-04-10)
+
+### Fixed
+
+- aggressive focus protection when CLI agent is connected ([016028b](https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/016028bbfdabe68dca4d0f429d6827d4f1bf00ea))
+- disable activateWindow by default to reduce focus disruption ([ca557f8](https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/ca557f8e8df7c5134d9931ae7935c2618f68f8c5))
+- restore sidebar focus after input blur ([23bcb8f](https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/23bcb8f0847f3e5115b70bc247febf51f40cdbcd))
+
 ### [0.6.2](https://github.com/s-hiraoku/vscode-sidebar-terminal/compare/v0.6.1...v0.6.2) (2026-04-10)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the "Secondary Terminal" extension will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [0.6.2](https://github.com/s-hiraoku/vscode-sidebar-terminal/compare/v0.6.1...v0.6.2) (2026-04-10)
+
+### Fixed
+
+- restore sidebar focus after input blur ([23bcb8f](https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/23bcb8f0847f3e5115b70bc247febf51f40cdbcd))
+
 ### [0.6.1](https://github.com/s-hiraoku/vscode-sidebar-terminal/compare/v0.6.0...v0.6.1) (2026-04-10)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-sidebar-terminal",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-sidebar-terminal",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "bundleDependencies": [
         "node-pty"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-sidebar-terminal",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-sidebar-terminal",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "bundleDependencies": [
         "node-pty"
       ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sidebar-terminal",
   "displayName": "Secondary Terminal",
   "description": "Production-ready VS Code extension with TypeScript-compliant terminal in sidebar, ProcessState/InteractionState management, and comprehensive session management.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publisher": "s-hiraoku",
   "sideEffects": false,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sidebar-terminal",
   "displayName": "Secondary Terminal",
   "description": "Production-ready VS Code extension with TypeScript-compliant terminal in sidebar, ProcessState/InteractionState management, and comprehensive session management.",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publisher": "s-hiraoku",
   "sideEffects": false,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -486,7 +486,7 @@
         },
         "secondaryTerminal.nativeNotification.activateWindow": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Bring VS Code window to foreground when a CLI agent completes processing"
         },
         "secondaryTerminal.nativeNotification.cooldownMs": {

--- a/src/core/ExtensionLifecycle.ts
+++ b/src/core/ExtensionLifecycle.ts
@@ -117,12 +117,12 @@ export class ExtensionLifecycle {
       this.focusProtectionService = new FocusProtectionService({
         isTerminalFocused: () => this.terminalManager?.isTerminalFocused() ?? false,
         isWebViewVisible: () => this.sidebarProvider?.isWebViewVisible() ?? false,
-        sendWebviewFocus: () => {
-          const activeId = this.terminalManager?.getActiveTerminalId();
-          if (this.sidebarProvider && activeId) {
+        sendWebviewFocus: (terminalId?: string) => {
+          const targetId = terminalId ?? this.terminalManager?.getActiveTerminalId();
+          if (this.sidebarProvider && targetId) {
             void this.sidebarProvider.sendMessageToWebview({
               command: 'focusTerminal',
-              terminalId: activeId,
+              terminalId: targetId,
             });
           }
         },
@@ -144,7 +144,11 @@ export class ExtensionLifecycle {
         // recent-focus guard expire and defeat focus protection.
         const originalSendInput = this.terminalManager.sendInput.bind(this.terminalManager);
         this.terminalManager.sendInput = (data: string, terminalId?: string) => {
-          focusProtection.notifyInteraction();
+          // Pass the terminal ID so focus protection knows which terminal to
+          // restore when focus is stolen — important when multiple sidebar
+          // terminals exist.
+          const targetId = terminalId ?? this.terminalManager?.getActiveTerminalId();
+          focusProtection.notifyInteraction(targetId);
           originalSendInput(data, terminalId);
         };
       }
@@ -431,10 +435,15 @@ export class ExtensionLifecycle {
           if (event.status === 'connected') {
             this.telemetryService?.trackCliAgentDetected(event.type || 'unknown');
             log(`📊 [TELEMETRY] CLI Agent detected: ${event.type}`);
+            // Enable aggressive focus protection while a CLI agent is connected,
+            // because the agent's VS Code extension may call terminal.show()
+            // repeatedly during MCP tool operations.
+            this.focusProtectionService?.notifyCliAgentConnected(true);
           } else if (event.status === 'disconnected') {
             // Track disconnection with session duration (if available)
             this.telemetryService?.trackCliAgentDisconnected(event.type || 'unknown', 0);
             log(`📊 [TELEMETRY] CLI Agent disconnected: ${event.type}`);
+            this.focusProtectionService?.notifyCliAgentConnected(false);
           }
         });
 

--- a/src/services/FocusProtectionService.ts
+++ b/src/services/FocusProtectionService.ts
@@ -9,8 +9,12 @@ export interface FocusProtectionDependencies {
    * Optional: send a focus command to the webview after executing the
    * view-focus command. Mirrors the two-step sequence used by
    * KeyboardShortcutService.focusTerminal() so that xterm.js regains DOM focus.
+   *
+   * @param terminalId - The sidebar terminal that should receive focus.
+   *   When provided, focus is restored to the specific terminal the user was
+   *   interacting with, not just whichever terminal happens to be active.
    */
-  sendWebviewFocus?: () => void;
+  sendWebviewFocus?: (terminalId?: string) => void;
 }
 
 /**
@@ -36,13 +40,26 @@ export class FocusProtectionService implements vscode.Disposable {
   private static readonly RECENT_FOCUS_WINDOW_MS = 600;
   private static readonly RECENT_INTERACTION_WINDOW_MS = 200;
 
+  /**
+   * When a CLI agent is connected, use a much longer focus window and shorter
+   * cooldown. The agent's VS Code extension calls terminal.show() during MCP
+   * tool operations which can happen at any time during a long-running task.
+   * 10 minutes covers even lengthy code-generation / multi-file edit sessions.
+   */
+  private static readonly CLI_AGENT_FOCUS_WINDOW_MS = 600_000;
+  /** Shorter cooldown because MCP tool calls can steal focus in rapid succession. */
+  private static readonly CLI_AGENT_COOLDOWN_MS = 150;
+
   private readonly _disposables = new DisposableStore();
   private readonly _deps: FocusProtectionDependencies;
   private _enabled: boolean;
+  private _cliAgentConnected = false;
   private _pendingTimer: ReturnType<typeof setTimeout> | undefined;
   private _lastRestoreTime = 0;
   private _lastFocusedTime = 0;
   private _lastInteractionTime = 0;
+  /** The sidebar terminal that was most recently interacted with. */
+  private _lastInteractedTerminalId: string | undefined;
 
   constructor(deps: FocusProtectionDependencies) {
     this._deps = deps;
@@ -90,6 +107,16 @@ export class FocusProtectionService implements vscode.Disposable {
   }
 
   /**
+   * Called when a CLI agent (e.g. Claude Code) connects or disconnects in the
+   * sidebar terminal. When connected, focus protection becomes more aggressive
+   * because the agent's VS Code extension may repeatedly call terminal.show()
+   * to steal focus during MCP tool operations.
+   */
+  public notifyCliAgentConnected(connected: boolean): void {
+    this._cliAgentConnected = connected;
+  }
+
+  /**
    * Called by the extension on user interaction (keystrokes / input) with the
    * sidebar terminal. Refreshes the recent-focus window so that long typing
    * sessions do not let the window expire while the user is actively working.
@@ -97,11 +124,14 @@ export class FocusProtectionService implements vscode.Disposable {
    * Only refreshes when the WebView is visible, to avoid false positives from
    * buffered messages arriving after the view has been hidden.
    */
-  public notifyInteraction(): void {
+  public notifyInteraction(terminalId?: string): void {
     if (!this._deps.isWebViewVisible()) return;
     const now = Date.now();
     this._lastFocusedTime = now;
     this._lastInteractionTime = now;
+    if (terminalId !== undefined) {
+      this._lastInteractedTerminalId = terminalId;
+    }
   }
 
   private _readSetting(): boolean {
@@ -110,7 +140,10 @@ export class FocusProtectionService implements vscode.Disposable {
 
   private _hadRecentFocus(): boolean {
     if (this._deps.isTerminalFocused()) return true;
-    return Date.now() - this._lastFocusedTime < FocusProtectionService.RECENT_FOCUS_WINDOW_MS;
+    const window = this._cliAgentConnected
+      ? FocusProtectionService.CLI_AGENT_FOCUS_WINDOW_MS
+      : FocusProtectionService.RECENT_FOCUS_WINDOW_MS;
+    return Date.now() - this._lastFocusedTime < window;
   }
 
   private _hadRecentInteraction(): boolean {
@@ -123,7 +156,10 @@ export class FocusProtectionService implements vscode.Disposable {
     if (!this._enabled) return false;
     if (!this._deps.isWebViewVisible()) return false;
     if (this._deps.isTerminalFocused()) return false;
-    if (!this._hadRecentInteraction()) return false;
+    // When a CLI agent is connected, skip the interaction check — the agent's
+    // VS Code extension steals focus during background MCP operations when the
+    // user is not actively typing.
+    if (!this._cliAgentConnected && !this._hadRecentInteraction()) return false;
     return this._hadRecentFocus();
   }
 
@@ -230,12 +266,18 @@ export class FocusProtectionService implements vscode.Disposable {
     this._clearPendingRestore();
 
     const now = Date.now();
-    if (now - this._lastRestoreTime < FocusProtectionService.COOLDOWN_MS) {
+    const cooldown = this._cliAgentConnected
+      ? FocusProtectionService.CLI_AGENT_COOLDOWN_MS
+      : FocusProtectionService.COOLDOWN_MS;
+    if (now - this._lastRestoreTime < cooldown) {
       log('🛡️ [FOCUS_PROTECTION] skip: cooldown active');
       return;
     }
 
     log('🛡️ [FOCUS_PROTECTION] scheduling focus restoration');
+    // Capture the terminal ID at schedule time, not at fire time, because
+    // the active terminal may change between scheduling and execution.
+    const targetTerminalId = this._lastInteractedTerminalId;
     this._pendingTimer = setTimeout(() => {
       this._pendingTimer = undefined;
       this._lastRestoreTime = Date.now();
@@ -243,9 +285,10 @@ export class FocusProtectionService implements vscode.Disposable {
       // The view id is `secondaryTerminal` (see package.json contributes.views).
       // Mirrors the working sequence in KeyboardShortcutService.focusTerminal().
       void vscode.commands.executeCommand('secondaryTerminal.focus');
-      // Then ask the webview to push DOM focus back into xterm.js.
+      // Then ask the webview to push DOM focus back into the specific xterm.js
+      // terminal that the user was interacting with.
       try {
-        this._deps.sendWebviewFocus?.();
+        this._deps.sendWebviewFocus?.(targetTerminalId);
       } catch (err) {
         log('🛡️ [FOCUS_PROTECTION] sendWebviewFocus failed:', err);
       }

--- a/src/services/FocusProtectionService.ts
+++ b/src/services/FocusProtectionService.ts
@@ -34,6 +34,7 @@ export class FocusProtectionService implements vscode.Disposable {
   private static readonly RESTORE_DELAY_MS = 150;
   private static readonly COOLDOWN_MS = 500;
   private static readonly RECENT_FOCUS_WINDOW_MS = 600;
+  private static readonly RECENT_INTERACTION_WINDOW_MS = 200;
 
   private readonly _disposables = new DisposableStore();
   private readonly _deps: FocusProtectionDependencies;
@@ -41,6 +42,7 @@ export class FocusProtectionService implements vscode.Disposable {
   private _pendingTimer: ReturnType<typeof setTimeout> | undefined;
   private _lastRestoreTime = 0;
   private _lastFocusedTime = 0;
+  private _lastInteractionTime = 0;
 
   constructor(deps: FocusProtectionDependencies) {
     this._deps = deps;
@@ -78,6 +80,12 @@ export class FocusProtectionService implements vscode.Disposable {
   public notifyFocusChanged(focused: boolean): void {
     if (focused) {
       this._lastFocusedTime = Date.now();
+      this._clearPendingRestore();
+      return;
+    }
+
+    if (this._shouldRestoreAfterBlur()) {
+      this._scheduleFocusRestore();
     }
   }
 
@@ -91,7 +99,9 @@ export class FocusProtectionService implements vscode.Disposable {
    */
   public notifyInteraction(): void {
     if (!this._deps.isWebViewVisible()) return;
-    this._lastFocusedTime = Date.now();
+    const now = Date.now();
+    this._lastFocusedTime = now;
+    this._lastInteractionTime = now;
   }
 
   private _readSetting(): boolean {
@@ -101,6 +111,20 @@ export class FocusProtectionService implements vscode.Disposable {
   private _hadRecentFocus(): boolean {
     if (this._deps.isTerminalFocused()) return true;
     return Date.now() - this._lastFocusedTime < FocusProtectionService.RECENT_FOCUS_WINDOW_MS;
+  }
+
+  private _hadRecentInteraction(): boolean {
+    return (
+      Date.now() - this._lastInteractionTime < FocusProtectionService.RECENT_INTERACTION_WINDOW_MS
+    );
+  }
+
+  private _shouldRestoreAfterBlur(): boolean {
+    if (!this._enabled) return false;
+    if (!this._deps.isWebViewVisible()) return false;
+    if (this._deps.isTerminalFocused()) return false;
+    if (!this._hadRecentInteraction()) return false;
+    return this._hadRecentFocus();
   }
 
   /**
@@ -192,10 +216,18 @@ export class FocusProtectionService implements vscode.Disposable {
       return;
     }
 
+    this._scheduleFocusRestore();
+  }
+
+  private _clearPendingRestore(): void {
     if (this._pendingTimer !== undefined) {
       clearTimeout(this._pendingTimer);
       this._pendingTimer = undefined;
     }
+  }
+
+  private _scheduleFocusRestore(): void {
+    this._clearPendingRestore();
 
     const now = Date.now();
     if (now - this._lastRestoreTime < FocusProtectionService.COOLDOWN_MS) {
@@ -221,10 +253,7 @@ export class FocusProtectionService implements vscode.Disposable {
   }
 
   public dispose(): void {
-    if (this._pendingTimer !== undefined) {
-      clearTimeout(this._pendingTimer);
-      this._pendingTimer = undefined;
-    }
+    this._clearPendingRestore();
     this._disposables.dispose();
   }
 }

--- a/src/test/vitest/unit/services/FocusProtectionService.test.ts
+++ b/src/test/vitest/unit/services/FocusProtectionService.test.ts
@@ -400,6 +400,67 @@ describe('FocusProtectionService', () => {
     });
   });
 
+  describe('terminal ID tracking (restore focus to the correct terminal)', () => {
+    it('should pass the last interacted terminal ID to sendWebviewFocus', () => {
+      mockIsTerminalFocused.mockReturnValue(true);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      // User interacts with terminal "3"
+      service.notifyInteraction('3');
+
+      fireActiveTerminalChanged({ name: 'Claude Code' });
+      vi.advanceTimersByTime(200);
+
+      expect(mockSendWebviewFocus).toHaveBeenCalledWith('3');
+    });
+
+    it('should pass undefined when no terminal ID was tracked', () => {
+      mockIsTerminalFocused.mockReturnValue(true);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      // No notifyInteraction with ID — legacy call without ID
+      service.notifyInteraction();
+
+      fireActiveTerminalChanged({ name: 'bash' });
+      vi.advanceTimersByTime(200);
+
+      expect(mockSendWebviewFocus).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should track the most recent terminal ID across multiple interactions', () => {
+      mockIsTerminalFocused.mockReturnValue(true);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      service.notifyInteraction('1');
+      service.notifyInteraction('2');
+      service.notifyInteraction('5');
+
+      fireActiveTerminalChanged({ name: 'Claude Code' });
+      vi.advanceTimersByTime(200);
+
+      expect(mockSendWebviewFocus).toHaveBeenCalledWith('5');
+    });
+
+    it('should restore focus to correct terminal in CLI agent mode', () => {
+      mockIsTerminalFocused.mockReturnValue(false);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      service.notifyCliAgentConnected(true);
+
+      // User submits prompt in terminal "2", then focus is gained
+      service.notifyInteraction('2');
+      service.notifyFocusChanged(true);
+      vi.advanceTimersByTime(100);
+
+      // Claude Code steals focus
+      fireActiveTerminalChanged({ name: 'Claude Code' });
+      vi.advanceTimersByTime(200);
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith('secondaryTerminal.focus');
+      expect(mockSendWebviewFocus).toHaveBeenCalledWith('2');
+    });
+  });
+
   describe('diagnostic logging (onDidOpenTerminal / describeTerminal)', () => {
     it('should register an onDidOpenTerminal listener', () => {
       expect(vscode.window.onDidOpenTerminal).toHaveBeenCalledOnce();
@@ -437,6 +498,152 @@ describe('FocusProtectionService', () => {
       }).not.toThrow();
 
       expect(vscode.commands.executeCommand).toHaveBeenCalledWith('secondaryTerminal.focus');
+    });
+  });
+
+  describe('CLI agent connected mode (aggressive focus protection)', () => {
+    it('should restore focus without recent interaction when CLI agent is connected', () => {
+      mockIsTerminalFocused.mockReturnValue(false);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      // Focus was gained recently
+      service.notifyFocusChanged(true);
+      vi.advanceTimersByTime(100);
+
+      // CLI agent connected — no interaction required
+      service.notifyCliAgentConnected(true);
+
+      fireActiveTerminalChanged({ name: 'Claude Code' });
+      vi.advanceTimersByTime(200);
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith('secondaryTerminal.focus');
+    });
+
+    it('should use shorter cooldown when CLI agent is connected', () => {
+      mockIsTerminalFocused.mockReturnValue(true);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      service.notifyCliAgentConnected(true);
+
+      // First restore
+      fireActiveTerminalChanged({ name: 'Claude Code' });
+      vi.advanceTimersByTime(200);
+      expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(1);
+
+      // After 200ms (less than normal 500ms cooldown, but enough for CLI agent mode)
+      vi.advanceTimersByTime(200);
+
+      // Second restore should work with shorter cooldown
+      fireActiveTerminalChanged({ name: 'Claude Code' });
+      vi.advanceTimersByTime(200);
+      expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(2);
+    });
+
+    it('should extend recent focus window when CLI agent is connected', () => {
+      mockIsTerminalFocused.mockReturnValue(false);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      service.notifyCliAgentConnected(true);
+
+      // Focus gained, then long time passes (beyond normal 600ms window)
+      service.notifyFocusChanged(true);
+      vi.advanceTimersByTime(30_000); // 30 seconds — well beyond normal window
+
+      // With CLI agent connected, the extended window (10 min) still covers this
+      fireActiveTerminalChanged({ name: 'Claude Code' });
+      vi.advanceTimersByTime(200);
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith('secondaryTerminal.focus');
+    });
+
+    it('should protect during long CLI agent processing sessions', () => {
+      mockIsTerminalFocused.mockReturnValue(false);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      service.notifyCliAgentConnected(true);
+
+      // User submitted a prompt, then CLI agent processes for 5 minutes
+      service.notifyFocusChanged(true);
+      vi.advanceTimersByTime(300_000); // 5 minutes
+
+      // Claude Code steals focus during processing
+      fireActiveTerminalChanged({ name: 'Claude Code' });
+      vi.advanceTimersByTime(200);
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith('secondaryTerminal.focus');
+    });
+
+    it('should NOT extend recent focus window beyond CLI agent window', () => {
+      mockIsTerminalFocused.mockReturnValue(false);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      service.notifyCliAgentConnected(true);
+
+      service.notifyFocusChanged(true);
+      // Wait beyond CLI agent extended window (10 min = 600_000ms)
+      vi.advanceTimersByTime(700_000);
+
+      fireActiveTerminalChanged({ name: 'bash' });
+      vi.advanceTimersByTime(200);
+
+      expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('should revert to normal behavior when CLI agent disconnects', () => {
+      mockIsTerminalFocused.mockReturnValue(false);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      service.notifyCliAgentConnected(true);
+      service.notifyFocusChanged(true);
+
+      // Disconnect CLI agent
+      service.notifyCliAgentConnected(false);
+
+      // Wait beyond normal RECENT_FOCUS_WINDOW_MS (600ms)
+      // After disconnect, the normal window applies → focus should NOT be restored
+      vi.advanceTimersByTime(800);
+
+      fireActiveTerminalChanged({ name: 'bash' });
+      vi.advanceTimersByTime(200);
+
+      expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('should still respect disabled setting even with CLI agent connected', () => {
+      vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+        get: vi.fn((key: string) => {
+          if (key === 'focusProtection') return false;
+          return undefined;
+        }),
+      } as any);
+
+      service.dispose();
+      (vscode.window as any)._onDidChangeActiveTerminalListeners.length = 0;
+      service = new FocusProtectionService({
+        isTerminalFocused: mockIsTerminalFocused,
+        isWebViewVisible: mockIsWebViewVisible,
+      });
+
+      service.notifyCliAgentConnected(true);
+      mockIsTerminalFocused.mockReturnValue(true);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      fireActiveTerminalChanged({ name: 'Claude Code' });
+      vi.advanceTimersByTime(200);
+
+      expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('should still require WebView visible even with CLI agent connected', () => {
+      mockIsTerminalFocused.mockReturnValue(true);
+      mockIsWebViewVisible.mockReturnValue(false);
+
+      service.notifyCliAgentConnected(true);
+
+      fireActiveTerminalChanged({ name: 'Claude Code' });
+      vi.advanceTimersByTime(200);
+
+      expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
     });
   });
 

--- a/src/test/vitest/unit/services/FocusProtectionService.test.ts
+++ b/src/test/vitest/unit/services/FocusProtectionService.test.ts
@@ -336,6 +336,36 @@ describe('FocusProtectionService', () => {
 
       expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
     });
+
+    it('should restore focus when blur happens immediately after recent interaction without active terminal change', () => {
+      mockIsTerminalFocused.mockReturnValue(true);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      service.notifyFocusChanged(true);
+      service.notifyInteraction();
+
+      mockIsTerminalFocused.mockReturnValue(false);
+      service.notifyFocusChanged(false);
+      vi.advanceTimersByTime(200);
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith('secondaryTerminal.focus');
+      expect(mockSendWebviewFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT restore focus on blur without recent interaction when active terminal does not change', () => {
+      mockIsTerminalFocused.mockReturnValue(true);
+      mockIsWebViewVisible.mockReturnValue(true);
+
+      service.notifyFocusChanged(true);
+      vi.advanceTimersByTime(250);
+
+      mockIsTerminalFocused.mockReturnValue(false);
+      service.notifyFocusChanged(false);
+      vi.advanceTimersByTime(200);
+
+      expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+      expect(mockSendWebviewFocus).not.toHaveBeenCalled();
+    });
   });
 
   describe('sendWebviewFocus dependency', () => {


### PR DESCRIPTION
## Summary

- Aggressive focus protection when a CLI agent (Claude Code) is connected — extends focus window to 10 minutes, reduces cooldown to 150ms, skips interaction requirement
- Track terminal ID through `notifyInteraction()` so focus restores to the correct sidebar terminal, not just whichever is active
- Disable `nativeNotification.activateWindow` by default to reduce compounding focus disruption
- Bump version to 0.6.3

## Root Cause

The Claude Code VS Code extension calls `terminal.show()` without `preserveFocus: true` during MCP tool operations (diff viewing, file editing, diagnostics). This steals focus from the sidebar terminal. Upstream issues: anthropics/claude-code#7618, anthropics/claude-code#23713.

## Changes

### FocusProtectionService
- `notifyCliAgentConnected(connected)` — enables aggressive mode when CLI agent detected
- `CLI_AGENT_FOCUS_WINDOW_MS = 600,000` (10 min) vs normal 600ms
- `CLI_AGENT_COOLDOWN_MS = 150` vs normal 500ms
- Skip `_hadRecentInteraction()` check in CLI agent mode (protect during background processing)
- `notifyInteraction(terminalId?)` — track which terminal was last interacted with
- `sendWebviewFocus(terminalId?)` — restore focus to the specific terminal
- Capture terminal ID at schedule time (not fire time) for correct restore after 150ms delay

### ExtensionLifecycle
- Wire CLI agent status events → `FocusProtectionService.notifyCliAgentConnected()`
- Pass terminal ID through `sendInput` wrapper → `notifyInteraction()`
- `sendWebviewFocus` callback accepts `terminalId` param, falls back to active terminal

### Settings
- `nativeNotification.activateWindow` default changed `true` → `false`

## Test plan

- [x] 39 unit tests pass (5 new test cases for CLI agent mode, 4 for terminal ID tracking, 1 for long processing sessions)
- [x] 4760 total unit tests pass
- [x] TypeScript compilation clean
- [x] Pre-commit hooks (tsc, eslint, prettier) pass
- [ ] Manual test: run Claude Code in sidebar terminal, verify focus stays in sidebar after prompt submission
- [ ] Manual test: verify correct terminal receives focus when multiple sidebar terminals exist

Refs: #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)