### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the "Secondary Terminal" extension will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0](https://github.com/s-hiraoku/vscode-sidebar-terminal/compare/v1.0.0...v1.1.0) (2026-06-07)
+
+### Fixed
+
+- **webview:** dispose terminal auto-save listeners ([b3ddc2b](https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/b3ddc2b3b924e9b61c1678395854dc63f48a7d14))
+
 ## [1.0.0](https://github.com/s-hiraoku/vscode-sidebar-terminal/compare/v0.6.3...v1.0.0) (2026-04-20)
 
 **First stable release.** Secondary Terminal graduates from 0.x to 1.0.0 after extensive real-world usage and maturity across all core features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **webview:** dispose terminal auto-save listeners ([b3ddc2b](https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/b3ddc2b3b924e9b61c1678395854dc63f48a7d14))
+- **webview:** dispose terminal auto-save listeners ([057a5bd](https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/057a5bd23f5e8e08d78d5d906d47b4cad227505b))
 
 ## [1.0.0](https://github.com/s-hiraoku/vscode-sidebar-terminal/compare/v0.6.3...v1.0.0) (2026-04-20)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-sidebar-terminal",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-sidebar-terminal",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "bundleDependencies": [
         "node-pty"
       ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sidebar-terminal",
   "displayName": "Secondary Terminal",
   "description": "Sidebar terminal for VS Code with AI agent awareness (Claude Code, Copilot, Gemini, Codex), split views, session persistence, and full IME support.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "publisher": "s-hiraoku",
   "sideEffects": false,
   "engines": {

--- a/src/test/vitest/unit/release/ReleaseReadiness.test.ts
+++ b/src/test/vitest/unit/release/ReleaseReadiness.test.ts
@@ -95,6 +95,9 @@ describe('1.1.0 release readiness', () => {
     expect(releaseMatch).not.toBeNull();
     expect(releaseMatch!.index!).toBeLessThan(changelog.indexOf(previousReleaseHeading));
     expect(changelog).toContain('dispose terminal auto-save listeners');
+    expect(changelog).toContain(
+      'https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/057a5bd23f5e8e08d78d5d906d47b4cad227505b'
+    );
   });
 
   it('does not leave debug console output in production TypeScript paths', () => {

--- a/src/test/vitest/unit/release/ReleaseReadiness.test.ts
+++ b/src/test/vitest/unit/release/ReleaseReadiness.test.ts
@@ -68,7 +68,7 @@ const findProductionConsoleCalls = (): string[] => {
   });
 };
 
-describe('1.0.0 release readiness', () => {
+describe('1.1.0 release readiness', () => {
   it('uses stable release package metadata', () => {
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')
@@ -78,23 +78,23 @@ describe('1.0.0 release readiness', () => {
       keywords: string[];
     };
 
-    expect(packageJson.version).toBe('1.0.0');
+    expect(packageJson.version).toBe('1.1.0');
     expect(packageJson.description).toBe(
       'Sidebar terminal for VS Code with AI agent awareness (Claude Code, Copilot, Gemini, Codex), split views, session persistence, and full IME support.'
     );
     expect(packageJson.keywords).toEqual(expectedKeywords);
   });
 
-  it('documents the 1.0.0 stable release at the top of the changelog', () => {
+  it('documents the 1.1.0 release at the top of the changelog', () => {
     const changelog = fs.readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
-    const stableReleaseHeading =
-      /^## \[1\.0\.0\]\(https:\/\/github\.com\/s-hiraoku\/vscode-sidebar-terminal\/compare\/v0\.6\.3\.\.\.v1\.0\.0\) \(\d{4}-\d{2}-\d{2}\)/m;
-    const stableMatch = changelog.match(stableReleaseHeading);
-    const previousReleaseHeading = '### [0.6.3]';
+    const releaseHeading =
+      /^## \[1\.1\.0\]\(https:\/\/github\.com\/s-hiraoku\/vscode-sidebar-terminal\/compare\/v1\.0\.0\.\.\.v1\.1\.0\) \(\d{4}-\d{2}-\d{2}\)/m;
+    const releaseMatch = changelog.match(releaseHeading);
+    const previousReleaseHeading = '## [1.0.0]';
 
-    expect(stableMatch).not.toBeNull();
-    expect(stableMatch!.index!).toBeLessThan(changelog.indexOf(previousReleaseHeading));
-    expect(changelog).toContain('**First stable release.**');
+    expect(releaseMatch).not.toBeNull();
+    expect(releaseMatch!.index!).toBeLessThan(changelog.indexOf(previousReleaseHeading));
+    expect(changelog).toContain('dispose terminal auto-save listeners');
   });
 
   it('does not leave debug console output in production TypeScript paths', () => {


### PR DESCRIPTION
## Summary
- Bump package version from 1.0.0 to 1.1.0
- Update package-lock and CHANGELOG for the 1.1.0 release
- Update release readiness tests to assert the 1.1.0 metadata

## Release notes
- Fixed webview terminal auto-save listener disposal from #647

## Verification
- npm run lint (passes; existing warnings remain)
- npm run compile (passes; existing webpack webview size warnings remain)
- npm run package (passes; existing webpack webview size warnings remain)
- npm run test:unit

## Publishing note
- No release tag was created or pushed in this PR. Tagging v1.1.0 after merge will trigger the GitHub release/publishing workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v1.1.0 Release

* **Bug Fixes**
  * Fixed terminal auto-save listener disposal in the webview to prevent memory leaks and improve stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->