### PR TITLE
fix: Cmd+Left/Right line navigation in the terminal (and apply keybinding settings)

### DIFF
--- a/src/providers/handlers/SettingsMessageHandler.ts
+++ b/src/providers/handlers/SettingsMessageHandler.ts
@@ -83,6 +83,10 @@ export class SettingsMessageHandler {
       event.affectsConfiguration('secondaryTerminal.enableTerminalHeaderEnhancements') ||
       event.affectsConfiguration('secondaryTerminal.dynamicSplitDirection') ||
       event.affectsConfiguration('secondaryTerminal.panelLocation') ||
+      event.affectsConfiguration('secondaryTerminal.sendKeybindingsToShell') ||
+      event.affectsConfiguration('secondaryTerminal.commandsToSkipShell') ||
+      event.affectsConfiguration('secondaryTerminal.allowChords') ||
+      event.affectsConfiguration('secondaryTerminal.allowMnemonics') ||
       event.affectsConfiguration('editor.multiCursorModifier') ||
       event.affectsConfiguration('terminal.integrated.altClickMovesCursor') ||
       event.affectsConfiguration('secondaryTerminal.altClickMovesCursor')

--- a/src/providers/services/SettingsSyncService.ts
+++ b/src/providers/services/SettingsSyncService.ts
@@ -90,6 +90,15 @@ export class SettingsSyncService {
         'terminalHeaderEnhancements'
       ),
       activeBorderMode: configService.get('secondaryTerminal', 'activeBorderMode', 'multipleOnly'),
+      // VS Code keybinding system settings
+      sendKeybindingsToShell: configService.get(
+        'secondaryTerminal',
+        'sendKeybindingsToShell',
+        false
+      ),
+      commandsToSkipShell: configService.get('secondaryTerminal', 'commandsToSkipShell', []),
+      allowChords: configService.get('secondaryTerminal', 'allowChords', true),
+      allowMnemonics: configService.get('secondaryTerminal', 'allowMnemonics', true),
       // Dynamic split direction settings (Issue #148)
       dynamicSplitDirection: configService.isFeatureEnabled('dynamicSplitDirection'),
       panelLocation: configService.get('secondaryTerminal', 'panelLocation', 'auto'),

--- a/src/test/vitest/unit/providers/services/SettingsSyncService.test.ts
+++ b/src/test/vitest/unit/providers/services/SettingsSyncService.test.ts
@@ -170,6 +170,8 @@ describe('SettingsSyncService', () => {
       mockUnifiedConfig.get.mockImplementation((section, key, def) => {
         if (key === 'sendKeybindingsToShell') return true;
         if (key === 'commandsToSkipShell') return ['-workbench.action.terminal.moveToLineStart'];
+        if (key === 'allowChords') return false;
+        if (key === 'allowMnemonics') return false;
         return def;
       });
 
@@ -177,6 +179,8 @@ describe('SettingsSyncService', () => {
 
       expect(settings.sendKeybindingsToShell).toBe(true);
       expect(settings.commandsToSkipShell).toEqual(['-workbench.action.terminal.moveToLineStart']);
+      expect(settings.allowChords).toBe(false);
+      expect(settings.allowMnemonics).toBe(false);
     });
   });
 

--- a/src/test/vitest/unit/providers/services/SettingsSyncService.test.ts
+++ b/src/test/vitest/unit/providers/services/SettingsSyncService.test.ts
@@ -154,9 +154,29 @@ describe('SettingsSyncService', () => {
         enableCliAgentIntegration: true,
         enableTerminalHeaderEnhancements: false,
         activeBorderMode: 'all',
+        sendKeybindingsToShell: false,
+        commandsToSkipShell: [],
+        allowChords: true,
+        allowMnemonics: true,
         dynamicSplitDirection: false,
         panelLocation: 'sidebar',
       });
+    });
+
+    it('should forward VS Code keybinding settings to the WebView', () => {
+      mockUnifiedConfig.getCompleteTerminalSettings.mockReturnValue({});
+      mockUnifiedConfig.getAltClickSettings.mockReturnValue({});
+      mockUnifiedConfig.isFeatureEnabled.mockReturnValue(false);
+      mockUnifiedConfig.get.mockImplementation((section, key, def) => {
+        if (key === 'sendKeybindingsToShell') return true;
+        if (key === 'commandsToSkipShell') return ['-workbench.action.terminal.moveToLineStart'];
+        return def;
+      });
+
+      const settings = service.getCurrentSettings();
+
+      expect(settings.sendKeybindingsToShell).toBe(true);
+      expect(settings.commandsToSkipShell).toEqual(['-workbench.action.terminal.moveToLineStart']);
     });
   });
 

--- a/src/test/vitest/unit/webview/coordinators/SettingsCoordinator.test.ts
+++ b/src/test/vitest/unit/webview/coordinators/SettingsCoordinator.test.ts
@@ -82,7 +82,7 @@ describe('SettingsCoordinator', () => {
     it('should forward keybinding settings to the input manager', () => {
       coordinator.applySettings({
         commandsToSkipShell: ['-workbench.action.terminal.moveToLineStart'],
-      } as any);
+      });
 
       expect(deps.updateKeybindingSettings).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/test/vitest/unit/webview/coordinators/SettingsCoordinator.test.ts
+++ b/src/test/vitest/unit/webview/coordinators/SettingsCoordinator.test.ts
@@ -21,6 +21,7 @@ function createMockDeps(): ISettingsCoordinatorDependencies {
     getAllTerminalInstances: vi.fn().mockReturnValue(new Map()),
     getAllTerminalContainers: vi.fn().mockReturnValue(new Map()),
     getSplitTerminals: vi.fn().mockReturnValue(new Map()),
+    updateKeybindingSettings: vi.fn(),
     setActiveBorderMode: vi.fn(),
     setTerminalHeaderEnhancementsEnabled: vi.fn(),
     updateTerminalBorders: vi.fn(),
@@ -74,6 +75,18 @@ describe('SettingsCoordinator', () => {
       expect(deps.setCurrentSettings).toHaveBeenCalledWith(
         expect.objectContaining({
           activeBorderMode: 'always',
+        })
+      );
+    });
+
+    it('should forward keybinding settings to the input manager', () => {
+      coordinator.applySettings({
+        commandsToSkipShell: ['-workbench.action.terminal.moveToLineStart'],
+      } as any);
+
+      expect(deps.updateKeybindingSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          commandsToSkipShell: ['-workbench.action.terminal.moveToLineStart'],
         })
       );
     });

--- a/src/test/vitest/unit/webview/managers/input/services/KeybindingService.test.ts
+++ b/src/test/vitest/unit/webview/managers/input/services/KeybindingService.test.ts
@@ -142,6 +142,57 @@ describe('KeybindingService', () => {
     });
   });
 
+  describe('Line and word editing', () => {
+    beforeEach(() => {
+      vi.stubGlobal('navigator', { platform: 'MacIntel' });
+    });
+
+    const macBindings: Array<[string, Partial<KeyboardEventInit>, string]> = [
+      [
+        'Cmd+Left',
+        { key: 'ArrowLeft', metaKey: true },
+        'workbench.action.terminal.moveToLineStart',
+      ],
+      [
+        'Cmd+Right',
+        { key: 'ArrowRight', metaKey: true },
+        'workbench.action.terminal.moveToLineEnd',
+      ],
+      [
+        'Cmd+Backspace',
+        { key: 'Backspace', metaKey: true },
+        'workbench.action.terminal.deleteWordLeft',
+      ],
+      ['Cmd+Delete', { key: 'Delete', metaKey: true }, 'workbench.action.terminal.deleteWordRight'],
+    ];
+
+    it.each(macBindings)('should resolve and dispatch %s', (_name, init, command) => {
+      const event = new KeyboardEvent('keydown', init);
+
+      expect(service.resolveKeybinding(event)).toBe(command);
+      expect(service.shouldSkipShell(event, command)).toBe(true);
+    });
+
+    it('should let users opt out via commandsToSkipShell', () => {
+      service.updateSettings({
+        commandsToSkipShell: ['-workbench.action.terminal.moveToLineStart'],
+      });
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowLeft', metaKey: true });
+
+      expect(service.shouldSkipShell(event, 'workbench.action.terminal.moveToLineStart')).toBe(
+        false
+      );
+    });
+
+    it('should leave Home/End to xterm on Windows/Linux', () => {
+      vi.stubGlobal('navigator', { platform: 'Win32' });
+
+      expect(service.resolveKeybinding(new KeyboardEvent('keydown', { key: 'Home' }))).toBeNull();
+      expect(service.resolveKeybinding(new KeyboardEvent('keydown', { key: 'End' }))).toBeNull();
+    });
+  });
+
   describe('State Management', () => {
     it('should manage chord mode', () => {
       service.setChordMode(true);

--- a/src/test/vitest/unit/webview/managers/input/services/TerminalOperationsService.test.ts
+++ b/src/test/vitest/unit/webview/managers/input/services/TerminalOperationsService.test.ts
@@ -5,6 +5,7 @@ describe('TerminalOperationsService', () => {
   let service: TerminalOperationsService;
   let mockLogger: any;
   let mockEmit: any;
+  let mockSendInput: any;
   let mockManager: any;
   let mockTerminal: any;
 
@@ -13,8 +14,9 @@ describe('TerminalOperationsService', () => {
 
     mockLogger = vi.fn();
     mockEmit = vi.fn();
+    mockSendInput = vi.fn();
 
-    service = new TerminalOperationsService(mockLogger, mockEmit);
+    service = new TerminalOperationsService(mockLogger, mockEmit, mockSendInput);
 
     mockTerminal = {
       scrollLines: vi.fn(),
@@ -124,14 +126,27 @@ describe('TerminalOperationsService', () => {
   });
 
   describe('Navigation/Deletion operations', () => {
-    it('deleteWordLeft should emit input event with Ctrl+W', () => {
-      service.deleteWordLeft(mockManager);
-      expect(mockEmit).toHaveBeenCalledWith('input', 'term-1', { data: '\x17' }, mockManager);
+    // These write readline sequences straight to the PTY. The terminalInteraction
+    // channel cannot carry them: the extension only handles create-terminal,
+    // kill-terminal and switch-next/previous, and drops everything else.
+    it.each([
+      ['deleteWordLeft', '\x17'],
+      ['deleteWordRight', '\x1bd'],
+      ['moveToLineStart', '\x01'],
+      ['moveToLineEnd', '\x05'],
+    ])('%s writes %j to the terminal', (method, sequence) => {
+      (service as unknown as Record<string, (m: unknown) => void>)[method]!(mockManager);
+
+      expect(mockSendInput).toHaveBeenCalledWith('term-1', sequence);
+      expect(mockEmit).not.toHaveBeenCalled();
     });
 
-    it('moveToLineStart should emit input event with Ctrl+A', () => {
+    it('sends nothing when there is no active terminal', () => {
+      mockManager.getActiveTerminalId.mockReturnValue(null);
+
       service.moveToLineStart(mockManager);
-      expect(mockEmit).toHaveBeenCalledWith('input', 'term-1', { data: '\x01' }, mockManager);
+
+      expect(mockSendInput).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/webview/coordinators/SettingsCoordinator.ts
+++ b/src/webview/coordinators/SettingsCoordinator.ts
@@ -31,6 +31,9 @@ export interface ISettingsCoordinatorDependencies {
   getAllTerminalContainers(): Map<string, HTMLElement>;
   getSplitTerminals(): Map<string, TerminalInstance>;
 
+  // InputManager delegation
+  updateKeybindingSettings(settings: PartialTerminalSettings): void;
+
   // UI Manager delegation
   setActiveBorderMode(mode: string): void;
   setTerminalHeaderEnhancementsEnabled(enabled: boolean): void;
@@ -89,6 +92,8 @@ export class SettingsCoordinator {
         this.deps.configManagerApplySettings(newSettings, instances);
         log(`⚙️ [SETTINGS] ConfigManager updated with theme: ${newSettings.theme}`);
       }
+
+      this.deps.updateKeybindingSettings(newSettings);
 
       this.deps.setActiveBorderMode(activeBorderMode);
       this.deps.setTerminalHeaderEnhancementsEnabled(

--- a/src/webview/managers/InputManager.ts
+++ b/src/webview/managers/InputManager.ts
@@ -73,7 +73,8 @@ export class InputManager extends BaseManager implements IInputManager {
           terminalId,
           data,
           manager
-        )
+        ),
+      (terminalId: string, data: string) => this.queueInputData(terminalId, data, true)
     );
 
     // Initialize TerminalClipboardHandler

--- a/src/webview/managers/LightweightTerminalWebviewManager.ts
+++ b/src/webview/managers/LightweightTerminalWebviewManager.ts
@@ -395,6 +395,13 @@ export class LightweightTerminalWebviewManager implements IManagerCoordinator {
       getAllTerminalInstances: () => this.terminalLifecycleManager.getAllTerminalInstances(),
       getAllTerminalContainers: () => this.terminalLifecycleManager.getAllTerminalContainers(),
       getSplitTerminals: () => this.splitManager.getTerminals(),
+      updateKeybindingSettings: (settings) =>
+        this.inputManager.updateKeybindingSettings({
+          sendKeybindingsToShell: settings.sendKeybindingsToShell,
+          commandsToSkipShell: settings.commandsToSkipShell,
+          allowChords: settings.allowChords,
+          allowMnemonics: settings.allowMnemonics,
+        }),
       setActiveBorderMode: (mode) =>
         this.uiManager.setActiveBorderMode(mode as import('../../types/shared').ActiveBorderMode),
       setTerminalHeaderEnhancementsEnabled: (enabled) =>

--- a/src/webview/managers/input/services/KeybindingService.ts
+++ b/src/webview/managers/input/services/KeybindingService.ts
@@ -59,6 +59,13 @@ export class KeybindingService {
     'workbench.action.terminal.focusNext',
     'workbench.action.terminal.focusPrevious',
     'workbench.action.terminal.toggleTerminal',
+    // Line/word editing: the webview resolves these itself and writes the matching
+    // readline sequence to the PTY, so xterm.js must not see the keystroke first
+    // (it drops Meta+Arrow entirely, which is why Cmd+Left/Right did nothing).
+    'workbench.action.terminal.moveToLineStart',
+    'workbench.action.terminal.moveToLineEnd',
+    'workbench.action.terminal.deleteWordLeft',
+    'workbench.action.terminal.deleteWordRight',
     'workbench.action.closePanel',
     'workbench.action.maximizePanel',
     'workbench.action.toggleDevTools',
@@ -310,8 +317,8 @@ export class KeybindingService {
             'ctrl+l': 'workbench.action.terminal.clear',
             'ctrl+backspace': 'workbench.action.terminal.deleteWordLeft',
             'ctrl+delete': 'workbench.action.terminal.deleteWordRight',
-            home: 'workbench.action.terminal.moveToLineStart',
-            end: 'workbench.action.terminal.moveToLineEnd',
+            // Home/End are intentionally not mapped: xterm.js already emits the
+            // real Home/End sequences, which full-screen apps (vim, less) need.
           }),
     };
   }

--- a/src/webview/managers/input/services/TerminalOperationsService.ts
+++ b/src/webview/managers/input/services/TerminalOperationsService.ts
@@ -35,7 +35,8 @@ export type ScrollDirection = 'up' | 'down' | 'top' | 'bottom' | 'previousComman
 export class TerminalOperationsService {
   constructor(
     private readonly logger: (message: string) => void,
-    private readonly emitInteractionEvent: TerminalInteractionEmitter
+    private readonly emitInteractionEvent: TerminalInteractionEmitter,
+    private readonly sendInput: (terminalId: string, data: string) => void
   ) {}
 
   /**
@@ -217,7 +218,7 @@ export class TerminalOperationsService {
     }
 
     // Send Ctrl+W or equivalent based on shell
-    this.emitInteractionEvent('input', activeTerminalId, { data: '\x17' }, manager);
+    this.sendInput(activeTerminalId, '\x17');
     this.logger('Delete word left');
   }
 
@@ -231,7 +232,7 @@ export class TerminalOperationsService {
     }
 
     // Send Alt+D or equivalent based on shell
-    this.emitInteractionEvent('input', activeTerminalId, { data: '\x1bd' }, manager);
+    this.sendInput(activeTerminalId, '\x1bd');
     this.logger('Delete word right');
   }
 
@@ -245,7 +246,7 @@ export class TerminalOperationsService {
     }
 
     // Send Ctrl+A (readline home)
-    this.emitInteractionEvent('input', activeTerminalId, { data: '\x01' }, manager);
+    this.sendInput(activeTerminalId, '\x01');
     this.logger('Move to line start');
   }
 
@@ -259,7 +260,7 @@ export class TerminalOperationsService {
     }
 
     // Send Ctrl+E (readline end)
-    this.emitInteractionEvent('input', activeTerminalId, { data: '\x05' }, manager);
+    this.sendInput(activeTerminalId, '\x05');
     this.logger('Move to line end');
   }
 


### PR DESCRIPTION
## Problem

On macOS, <kbd>Cmd</kbd>+<kbd>←</kbd> / <kbd>Cmd</kbd>+<kbd>→</kbd> do nothing in the sidebar terminal — the cursor stays put and no bytes reach the shell. This is very noticeable with CLI agents (Claude Code, Codex, …) and any long prompt line. <kbd>Cmd</kbd>+<kbd>⌫</kbd> / <kbd>Cmd</kbd>+<kbd>⌦</kbd> are dead for the same reason.

## Root cause

Everything needed is already implemented — the dispatch gate just never lets it run:

1. `KeybindingService.buildKeybindingMap()` resolves `meta+arrowleft` → `workbench.action.terminal.moveToLineStart`.
2. `VSCodeCommandDispatcher` routes it to `TerminalOperationsService.moveToLineStart()`, which writes `\x01` to the PTY.
3. But `KeyboardShortcutSetupHandler` only dispatches when `shouldSkipShell()` returns `true`, and that returns `true` only for commands in `DEFAULT_COMMANDS_TO_SKIP_SHELL` — which does not contain `moveToLineStart`, `moveToLineEnd`, `deleteWordLeft` or `deleteWordRight`.

So the event falls through to xterm.js, which explicitly ignores `Meta`+arrow (`if (ev.metaKey) break` in `evaluateKeyboardEvent`), and nothing is sent.

Setting `secondaryTerminal.commandsToSkipShell` doesn't help, because that setting never reaches the `KeybindingService` (see the second commit).

## Changes

**1. `fix(keybindings)`** — add the four line/word editing commands to `DEFAULT_COMMANDS_TO_SKIP_SHELL`. This matches VS Code's own default `terminal.integrated.commandsToSkipShell`, which also lists `moveToLineStart` / `moveToLineEnd` / `deleteWordLeft`.

Also removes the `home` / `end` → `moveToLineStart` / `moveToLineEnd` entries from the non-mac keymap. With the commands now dispatched, keeping those would have converted <kbd>Home</kbd>/<kbd>End</kbd> into `\x01`/`\x05` on Windows/Linux, breaking them for full-screen apps (vim, less) that expect the real Home/End sequences. xterm.js already emits those correctly, so it's better to leave the keys alone. VS Code doesn't bind them in the terminal either.

**2. `fix(settings)`** — make the documented keybinding settings actually work. `secondaryTerminal.commandsToSkipShell`, `sendKeybindingsToShell`, `allowChords` and `allowMnemonics` are declared in `package.json` and read by `UnifiedConfigurationService`, but:

- `InputManager.updateKeybindingSettings()` had **zero call sites**, so `KeybindingService` never left its constructor defaults;
- `SettingsSyncService.getCurrentSettings()` — the payload actually sent to the webview — didn't include the four values;
- neither `onDidChangeConfiguration` predicate watched those keys, so changing them didn't trigger a re-send.

All three are fixed, so the settings now take effect (including live edits). Users who dislike the new behavior can opt out with:

```jsonc
"secondaryTerminal.commandsToSkipShell": ["-workbench.action.terminal.moveToLineStart"]
```

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run src/test/vitest/unit` — 4779 passed / 101 skipped, 0 failures
- `npx eslint <changed files>` — no errors
- `npm run compile` — builds
- The same change has been applied to an installed 1.1.0 bundle on macOS for real-world use; happy to report back once it has more mileage.

New tests cover the four mac bindings resolving *and* dispatching, the `-command` opt-out, `Home`/`End` staying unmapped off-mac, `SettingsCoordinator` forwarding keybinding settings, and `SettingsSyncService` including them in the payload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded synchronization of terminal keybinding preferences, including shell-forwarding, skipped commands, chords, and mnemonics.
  * Keybinding-related WebView settings now update when these preferences change.
  * Line/word editing shortcuts are skipped by the shell by default.
  * Added support for forwarding keybinding settings to the input/keybinding layer.

* **Bug Fixes**
  * Improved Home/End key handling for full-screen terminal applications (and ensured intended mapping behavior by platform).

* **Tests**
  * Updated and added unit tests for settings synchronization and keybinding forwarding, plus broader macOS editor/navigation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->