### PR TITLE
fix(keybindings): stop swallowing workbench keybindings

### DIFF
--- a/src/test/vitest/unit/webview/managers/input/handlers/KeyboardShortcutSetupHandler.test.ts
+++ b/src/test/vitest/unit/webview/managers/input/handlers/KeyboardShortcutSetupHandler.test.ts
@@ -156,6 +156,36 @@ describe('KeyboardShortcutSetupHandler', () => {
       );
     });
 
+    it('should let workbench-owned commands reach VS Code', () => {
+      const mockManager = {} as any;
+      (mockDeps.resolveKeybinding as ReturnType<typeof vi.fn>).mockReturnValue(
+        'workbench.action.showCommands'
+      );
+      (mockDeps.shouldSkipShell as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      handler.setupKeyboardShortcuts(mockManager);
+
+      const registerCall = (mockDeps.eventRegistry.register as ReturnType<typeof vi.fn>).mock
+        .calls[0];
+      const shortcutHandler = registerCall![3] as (event: KeyboardEvent) => void;
+
+      const event = new dom.window.KeyboardEvent('keydown', {
+        key: 'P',
+        metaKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const preventSpy = vi.spyOn(event, 'preventDefault');
+      const stopSpy = vi.spyOn(event, 'stopPropagation');
+      shortcutHandler(event);
+
+      // The webview cannot open the command palette; swallowing the key means
+      // nothing happens at all.
+      expect(preventSpy).not.toHaveBeenCalled();
+      expect(stopSpy).not.toHaveBeenCalled();
+      expect(mockDeps.handleVSCodeCommand).not.toHaveBeenCalled();
+    });
+
     it('should fall through to legacy shortcuts when no VS Code command matches', () => {
       const mockManager = {
         profileManager: { showProfileSelector: vi.fn() },

--- a/src/test/vitest/unit/webview/managers/input/services/WorkbenchCommands.test.ts
+++ b/src/test/vitest/unit/webview/managers/input/services/WorkbenchCommands.test.ts
@@ -1,0 +1,28 @@
+/**
+ * WorkbenchCommands Unit Tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isWorkbenchOwnedCommand } from '../../../../../../../webview/managers/input/services/WorkbenchCommands';
+
+describe('isWorkbenchOwnedCommand', () => {
+  it.each([
+    'workbench.action.showCommands',
+    'workbench.action.quickOpen',
+    'workbench.action.toggleDevTools',
+    'workbench.action.reloadWindow',
+    'workbench.action.zoomIn',
+    'workbench.action.closePanel',
+  ])('claims %s for the workbench', (command) => {
+    expect(isWorkbenchOwnedCommand(command)).toBe(true);
+  });
+
+  it.each([
+    'workbench.action.terminal.new',
+    'workbench.action.terminal.clear',
+    'workbench.action.terminal.copySelection',
+    'workbench.action.terminal.moveToLineStart',
+  ])('leaves %s to the webview', (command) => {
+    expect(isWorkbenchOwnedCommand(command)).toBe(false);
+  });
+});

--- a/src/webview/managers/input/handlers/KeyboardShortcutSetupHandler.ts
+++ b/src/webview/managers/input/handlers/KeyboardShortcutSetupHandler.ts
@@ -14,6 +14,7 @@
 
 import { IManagerCoordinator } from '../../../interfaces/ManagerInterfaces';
 import { EventHandlerRegistry } from '../../../utils/EventHandlerRegistry';
+import { isWorkbenchOwnedCommand } from '../services/WorkbenchCommands';
 
 /**
  * Keyboard event constants
@@ -97,6 +98,10 @@ export class KeyboardShortcutSetupHandler {
 
       // If should skip shell, handle as VS Code command
       if (shouldSkip && resolvedCommand) {
+        if (isWorkbenchOwnedCommand(resolvedCommand)) {
+          this.deps.logger(`Leaving ${resolvedCommand} to the workbench`);
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         this.deps.handleVSCodeCommand(resolvedCommand, manager);

--- a/src/webview/managers/input/services/WorkbenchCommands.ts
+++ b/src/webview/managers/input/services/WorkbenchCommands.ts
@@ -1,0 +1,26 @@
+/**
+ * Commands that belong to the VS Code workbench, not the terminal webview.
+ *
+ * They are on the skip-shell list so the keystroke is kept away from the PTY,
+ * but the webview cannot execute them — the workbench does, and only if the
+ * event is left to propagate. Swallowing them makes the key do nothing at all.
+ */
+const WORKBENCH_OWNED_COMMANDS = new Set([
+  'workbench.action.quickOpen',
+  'workbench.action.showCommands',
+  'workbench.action.togglePanel',
+  'workbench.action.closePanel',
+  'workbench.action.maximizePanel',
+  'workbench.action.toggleSidebarVisibility',
+  'workbench.action.toggleDevTools',
+  'workbench.action.reloadWindow',
+  'workbench.action.reloadWindowWithExtensionsDisabled',
+  'workbench.action.zoomIn',
+  'workbench.action.zoomOut',
+  'workbench.action.zoomReset',
+  'workbench.action.terminal.openNativeConsole',
+]);
+
+export function isWorkbenchOwnedCommand(command: string): boolean {
+  return WORKBENCH_OWNED_COMMANDS.has(command);
+}


### PR DESCRIPTION
## Current behavior

Pressing <kbd>Cmd/Ctrl+Shift+P</kbd> while the sidebar terminal has focus does nothing. The command palette never opens, and the keystroke is not sent to the shell either — it disappears.

The same applies to <kbd>Cmd/Ctrl+P</kbd> (Quick Open), <kbd>F12</kbd> (Dev Tools), <kbd>Cmd/Ctrl+R</kbd> (Reload Window), <kbd>Cmd/Ctrl+Shift+U</kbd> (Close Panel), and the zoom bindings.

### Cause

These keys resolve to commands that are on `DEFAULT_COMMANDS_TO_SKIP_SHELL`, so `shouldSkipShell()` returns `true` and `KeyboardShortcutSetupHandler` intercepts the event:

```ts
if (shouldSkip && resolvedCommand) {
  event.preventDefault();
  event.stopPropagation();
  this.deps.handleVSCodeCommand(resolvedCommand, manager);
  return;
}
```

But the webview cannot execute any of them. `VSCodeCommandDispatcher` only logs and returns:

```ts
case 'workbench.action.showCommands':
  this.deps.logger('Command Palette not implemented in terminal webview');
  break;
```

So the event is cancelled, VS Code never sees it, and nothing happens.

The `commandsToSkipShell` concept is being misapplied. In VS Code it means *the workbench handles this instead of the shell*. Inside a webview, letting the workbench handle it means **not** calling `preventDefault` — the event has to be allowed to propagate.

## New behavior

Commands owned by the workbench are left alone so VS Code receives the keystroke and runs them. Commands the webview can actually execute (terminal new/split/clear/copy/paste/find/scroll, line and word operations) are still intercepted exactly as before.

## Notes

- This does not change whether the key reaches the shell. The shortcut handler is registered on `document` in the bubble phase, so xterm.js's textarea handler has already run by the time it fires — `preventDefault` there could never suppress terminal input. On macOS this is moot since xterm does not translate `Cmd` combinations; on Linux/Windows `Ctrl+P` reaches the shell as `\x10` both before and after this change. That is a separate pre-existing issue, best fixed via `attachCustomKeyEventHandler` or by having the extension run the command through `vscode.commands.executeCommand`.
- With `secondaryTerminal.focusProtection` enabled (the default) and a CLI agent connected, `FocusProtectionService` restores focus ~150ms after any blur, which dismisses the palette right after it opens. That is tracked separately; this change is a prerequisite for the palette opening at all.

## Tests

- `WorkbenchCommands.test.ts` — covers the classification both ways.
- `KeyboardShortcutSetupHandler.test.ts` — asserts workbench commands are not cancelled or dispatched; the existing case for `workbench.action.terminal.new` still asserts interception is preserved.

Both were verified to fail against the unfixed handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut handling so workbench-owned VS Code commands are passed through correctly.
  * Prevented these commands from being intercepted or executed by the terminal webview.
  * Preserved existing handling for commands intended for the webview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->