### PR TITLE
fix(persistence): honour enablePersistentSessions when restoring

### DIFF
--- a/src/services/persistence/ExtensionPersistenceService.ts
+++ b/src/services/persistence/ExtensionPersistenceService.ts
@@ -289,6 +289,14 @@ export class ExtensionPersistenceService implements vscode.Disposable {
     try {
       const config = this.getPersistenceConfig();
 
+      // Sessions stored before the setting was turned off stay in workspaceState,
+      // so without this the corpse of an old session is restored forever.
+      if (!config.enablePersistentSessions) {
+        log('⏭️ Persistence disabled by config');
+        this.isRestoring = false;
+        return { success: false, message: 'Persistence disabled' };
+      }
+
       // Load session data
       const sessionData = this.context.workspaceState.get<SessionStorageData>(
         ExtensionPersistenceService.STORAGE_KEY

--- a/src/test/vitest/unit/services/persistence/ExtensionPersistenceService.test.ts
+++ b/src/test/vitest/unit/services/persistence/ExtensionPersistenceService.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type * as vscode from 'vscode';
+import * as vscodeApi from 'vscode';
 
 import '../../../../shared/TestSetup';
 import { ExtensionPersistenceService } from '../../../../../services/persistence/ExtensionPersistenceService';
@@ -325,6 +326,47 @@ describe('ExtensionPersistenceService', () => {
       await (service as any).batchRestoreTerminals(sessionData);
 
       expect(terminalManager.updateTerminalHeader).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('restoreSession honours enablePersistentSessions', () => {
+    const stubConfig = (enablePersistentSessions: boolean): void => {
+      vi.spyOn(vscodeApi.workspace, 'getConfiguration').mockReturnValue({
+        get: (key: string, defaultValue?: unknown) =>
+          key === 'enablePersistentSessions' ? enablePersistentSessions : defaultValue,
+      } as unknown as vscode.WorkspaceConfiguration);
+    };
+
+    it('restores nothing when persistence is disabled', async () => {
+      stubConfig(false);
+      // No live terminals, so nothing else short-circuits the restore.
+      terminalManager.getTerminals.mockReturnValue([]);
+      workspaceState.get.mockReturnValue({
+        terminals: [
+          { id: 'terminal-1', name: 'Terminal 1', number: 1, cwd: '/tmp', isActive: true },
+        ],
+        activeTerminalId: 'terminal-1',
+        timestamp: Date.now(),
+        version: '4.0.0',
+      });
+
+      const result = await service.restoreSession();
+
+      // A session stored before the setting was turned off must not come back.
+      expect(result.message).toBe('Persistence disabled');
+      expect(result.success).toBe(false);
+      expect(terminalManager.createTerminal).not.toHaveBeenCalled();
+    });
+
+    it('still reads storage when persistence is enabled', async () => {
+      stubConfig(true);
+      terminalManager.getTerminals.mockReturnValue([]);
+      workspaceState.get.mockReturnValue(undefined);
+
+      const result = await service.restoreSession();
+
+      expect(workspaceState.get).toHaveBeenCalled();
+      expect(result.message).toBe('No session found');
     });
   });
 });


### PR DESCRIPTION
## Current behavior

Setting `secondaryTerminal.enablePersistentSessions` to `false` does not stop terminals being restored. On every window reload the previous terminals reappear — but their PTY processes died with the extension host, so what comes back is UI only: a terminal with a prompt that never responds.

Nothing the user can change in settings fixes it. Turning the setting off, setting `persistentSessionReviveProcess` to `never`, and setting `persistentSessionScrollback` to `0` all leave the behaviour unchanged.

### Cause

The setting is only enforced on the save path:

```ts
// saveCurrentSession()
const config = this.getPersistenceConfig();
if (!config.enablePersistentSessions) {
  log('⏭️ Persistence disabled by config');
  return { success: true, terminalCount: 0, message: 'Persistence disabled' };
}
```

`restoreSession()` reads the config as well, but only ever uses it for the expiry window:

```ts
const config = this.getPersistenceConfig();
// ...no enablePersistentSessions check...
const sessionData = this.context.workspaceState.get<SessionStorageData>(STORAGE_KEY);
```

The only reference to `config` in the whole function is `config.persistentSessionExpiryDays`.

So sessions written *before* the setting was turned off remain in `workspaceState` under `terminal-session-unified` and are restored indefinitely. Disabling persistence stops new writes but cannot reach data already stored. The only escape is the `secondaryTerminal.clearSession` command, run once per workspace since the storage is workspace-scoped.

## New behavior

`restoreSession()` returns early when persistence is disabled, so turning the setting off means nothing is restored rather than only nothing new being recorded.

## Tests

Two cases in `ExtensionPersistenceService.test.ts`:

- persistence disabled with a stored session present → restore returns `Persistence disabled` and no terminals are created
- persistence enabled → storage is still read (guards against the fix short-circuiting the normal path)

Verified red against the unfixed code. Worth noting the disabled-case test initially passed for the wrong reason — the shared fixture returns two live terminals, so `restoreSession()` was bailing at the earlier "Terminals already exist" guard and never reaching the config check. The test now clears that fixture so it genuinely exercises this path.

## Notes

Separate from the fix: the restored terminal presents a normal-looking prompt even though its process is gone, which is what makes this confusing rather than merely wrong. VS Code's own terminals survive a reload because their PTYs live in a pty host process that outlives the window; PTYs here are spawned inside the extension host and die with it, so "restore" can only ever replay scrollback into a fresh xterm. Making that state visible — or reconnecting to a live shell — seems worth considering separately.