### PR TITLE
fix(scrolling): honour terminal.integrated scroll sensitivity

### DIFF
--- a/src/config/UnifiedConfigurationService.ts
+++ b/src/config/UnifiedConfigurationService.ts
@@ -460,6 +460,31 @@ export class UnifiedConfigurationService implements Disposable {
   }
 
   /**
+   * Get scroll sensitivity settings (VS Code standard)
+   *
+   * Mirrors xtermTerminal.ts, which feeds these into xterm.js as
+   * scrollSensitivity / fastScrollSensitivity.
+   */
+  public getScrollSensitivitySettings(): {
+    scrollSensitivity: number;
+    fastScrollSensitivity: number;
+  } {
+    this.initialize();
+    return {
+      scrollSensitivity: this.get(
+        CONFIG_SECTIONS.TERMINAL_INTEGRATED,
+        CONFIG_KEYS.MOUSE_WHEEL_SCROLL_SENSITIVITY,
+        1
+      ),
+      fastScrollSensitivity: this.get(
+        CONFIG_SECTIONS.TERMINAL_INTEGRATED,
+        CONFIG_KEYS.FAST_SCROLL_SENSITIVITY,
+        5
+      ),
+    };
+  }
+
+  /**
    * Get font family with VS Code hierarchy
    * Priority: secondaryTerminal.fontFamily > terminal.integrated.fontFamily > editor.fontFamily > system default
    */

--- a/src/providers/services/SettingsSyncService.ts
+++ b/src/providers/services/SettingsSyncService.ts
@@ -74,6 +74,7 @@ export class SettingsSyncService {
     const configService = getUnifiedConfigurationService();
     const settings = configService.getCompleteTerminalSettings();
     const altClickSettings = configService.getAltClickSettings();
+    const scrollSettings = configService.getScrollSensitivitySettings();
 
     // Use unified service for all configuration access
     return {
@@ -81,6 +82,9 @@ export class SettingsSyncService {
       theme: settings.theme || 'auto',
       // Scrollback buffer size (secondaryTerminal.scrollback setting)
       scrollback: configService.get('secondaryTerminal', 'scrollback', 2000),
+      // Scroll speed, shared with the integrated terminal
+      scrollSensitivity: scrollSettings.scrollSensitivity,
+      fastScrollSensitivity: scrollSettings.fastScrollSensitivity,
       // VS Code standard settings for Alt+Click functionality
       altClickMovesCursor: altClickSettings.altClickMovesCursor,
       multiCursorModifier: altClickSettings.multiCursorModifier,

--- a/src/test/vitest/unit/config/UnifiedConfigurationService.test.ts
+++ b/src/test/vitest/unit/config/UnifiedConfigurationService.test.ts
@@ -574,6 +574,38 @@ describe('UnifiedConfigurationService', () => {
     });
   });
 
+  describe('Scroll Sensitivity Configuration', () => {
+    const stubTerminalIntegrated = (values: Record<string, number>) => {
+      const terminalIntegratedConfig = {
+        get: vi.fn((key: string, def: unknown) => values[key] ?? def),
+      };
+      (vscode.workspace.getConfiguration as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        (section?: string) =>
+          section === CONFIG_SECTIONS.TERMINAL_INTEGRATED
+            ? terminalIntegratedConfig
+            : mockWorkspaceConfiguration
+      );
+    };
+
+    it('should read sensitivity from terminal.integrated', () => {
+      stubTerminalIntegrated({ mouseWheelScrollSensitivity: 3, fastScrollSensitivity: 8 });
+
+      expect(service.getScrollSensitivitySettings()).toEqual({
+        scrollSensitivity: 3,
+        fastScrollSensitivity: 8,
+      });
+    });
+
+    it('should fall back to the VS Code defaults', () => {
+      stubTerminalIntegrated({});
+
+      expect(service.getScrollSensitivitySettings()).toEqual({
+        scrollSensitivity: 1,
+        fastScrollSensitivity: 5,
+      });
+    });
+  });
+
   describe('Alt+Click Configuration', () => {
     it('should get Alt+Click settings', () => {
       const terminalIntegratedConfig = { get: vi.fn() };

--- a/src/test/vitest/unit/providers/services/SettingsSyncService.test.ts
+++ b/src/test/vitest/unit/providers/services/SettingsSyncService.test.ts
@@ -17,6 +17,7 @@ const { mockUnifiedConfig } = vi.hoisted(() => ({
     update: vi.fn().mockResolvedValue(undefined),
     isFeatureEnabled: vi.fn(),
     getAltClickSettings: vi.fn(),
+    getScrollSensitivitySettings: vi.fn(),
   },
 }));
 
@@ -130,6 +131,10 @@ describe('SettingsSyncService', () => {
         altClickMovesCursor: true,
         multiCursorModifier: 'alt',
       });
+      mockUnifiedConfig.getScrollSensitivitySettings.mockReturnValue({
+        scrollSensitivity: 3,
+        fastScrollSensitivity: 5,
+      });
       mockUnifiedConfig.get.mockImplementation((section, key, def) => {
         if (key === 'scrollback') return 5000;
         if (key === 'activeBorderMode') return 'all';
@@ -149,6 +154,8 @@ describe('SettingsSyncService', () => {
         cursorBlink: true,
         theme: 'dark',
         scrollback: 5000,
+        scrollSensitivity: 3,
+        fastScrollSensitivity: 5,
         altClickMovesCursor: true,
         multiCursorModifier: 'alt',
         enableCliAgentIntegration: true,
@@ -157,6 +164,22 @@ describe('SettingsSyncService', () => {
         dynamicSplitDirection: false,
         panelLocation: 'sidebar',
       });
+    });
+
+    it('forwards scroll sensitivity so the sidebar scrolls like the integrated terminal', () => {
+      mockUnifiedConfig.getCompleteTerminalSettings.mockReturnValue({});
+      mockUnifiedConfig.getAltClickSettings.mockReturnValue({});
+      mockUnifiedConfig.get.mockImplementation((_section, _key, def) => def);
+      mockUnifiedConfig.isFeatureEnabled.mockReturnValue(false);
+      mockUnifiedConfig.getScrollSensitivitySettings.mockReturnValue({
+        scrollSensitivity: 7,
+        fastScrollSensitivity: 9,
+      });
+
+      const settings = service.getCurrentSettings();
+
+      expect(settings.scrollSensitivity).toBe(7);
+      expect(settings.fastScrollSensitivity).toBe(9);
     });
   });
 

--- a/src/test/vitest/unit/webview/managers/UIManager.test.ts
+++ b/src/test/vitest/unit/webview/managers/UIManager.test.ts
@@ -343,6 +343,23 @@ describe('UIManager', () => {
       expect(mockTerminal.options.scrollback).toBe(1000);
     });
 
+    it('should apply scroll sensitivity from settings', () => {
+      const mockTerminal = {
+        options: {},
+        refresh: vi.fn(),
+        rows: 24,
+        element: document.createElement('div'),
+      } as any;
+
+      uiManager.applyAllVisualSettings(mockTerminal, {
+        scrollSensitivity: 3,
+        fastScrollSensitivity: 8,
+      });
+
+      expect(mockTerminal.options.scrollSensitivity).toBe(3);
+      expect(mockTerminal.options.fastScrollSensitivity).toBe(8);
+    });
+
     it('should apply cursor blink from settings.cursorBlink', () => {
       const mockTerminal = {
         options: {},

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -119,6 +119,8 @@ export interface PartialTerminalSettings {
   theme?: string;
   cursorBlink?: boolean;
   scrollback?: number;
+  scrollSensitivity?: number;
+  fastScrollSensitivity?: number;
   bellSound?: boolean;
   altClickMovesCursor?: boolean;
   multiCursorModifier?: string;
@@ -378,6 +380,8 @@ export const CONFIG_KEYS = {
 
   // terminal.integrated section
   ALT_CLICK_MOVES_CURSOR: 'altClickMovesCursor',
+  MOUSE_WHEEL_SCROLL_SENSITIVITY: 'mouseWheelScrollSensitivity',
+  FAST_SCROLL_SENSITIVITY: 'fastScrollSensitivity',
   SHELL_WINDOWS: 'shell.windows',
   SHELL_OSX: 'shell.osx',
   SHELL_LINUX: 'shell.linux',

--- a/src/webview/managers/ConfigManager.ts
+++ b/src/webview/managers/ConfigManager.ts
@@ -112,6 +112,8 @@ export class ConfigManager implements IConfigManager {
     fontFamily: 'Consolas, "Courier New", monospace',
     theme: 'auto',
     cursorBlink: true,
+    scrollSensitivity: 1,
+    fastScrollSensitivity: 5,
     enableCliAgentIntegration: true,
     enableTerminalHeaderEnhancements: true,
     // Terminal profiles (will be populated from VS Code settings)

--- a/src/webview/managers/UIManager.ts
+++ b/src/webview/managers/UIManager.ts
@@ -525,6 +525,16 @@ export class UIManager extends BaseManager implements IUIManager {
       uiLogger.debug(`Applied scrollback: ${settings.scrollback}`);
     }
 
+    // Apply scroll speed
+    if (settings.scrollSensitivity !== undefined) {
+      terminal.options.scrollSensitivity = settings.scrollSensitivity;
+      uiLogger.debug(`Applied scroll sensitivity: ${settings.scrollSensitivity}`);
+    }
+    if (settings.fastScrollSensitivity !== undefined) {
+      terminal.options.fastScrollSensitivity = settings.fastScrollSensitivity;
+      uiLogger.debug(`Applied fast scroll sensitivity: ${settings.fastScrollSensitivity}`);
+    }
+
     // Bell sound is not supported in xterm.js options
     // Terminal bell handling would be implemented differently
   }


### PR DESCRIPTION
## Current behavior

The sidebar terminal scrolls at a different speed from the integrated terminal. Anyone who has tuned `terminal.integrated.mouseWheelScrollSensitivity` gets two terminals that scroll differently, with no setting that affects the sidebar one.

### Cause

`TerminalConfigService.createDefaultTerminalConfig()` hardcodes the values passed to `new Terminal(...)`:

```ts
fastScrollSensitivity: 5,
scrollSensitivity: 1,
```

Those are the only two occurrences of `scrollSensitivity` in `src/`. Nothing overrides them at runtime, and nothing reads `terminal.integrated.mouseWheelScrollSensitivity` anywhere in the extension.

xterm.js does apply the option — scrolling goes through a `ScrollableElement` configured with `mouseWheelScrollSensitivity: this._optionsService.rawOptions.scrollSensitivity` — so the sidebar is pinned to the xterm default of `1` while VS Code's terminal follows the user's setting.

## New behavior

`mouseWheelScrollSensitivity` and `fastScrollSensitivity` are read from `terminal.integrated` alongside the other settings already sourced from there (Alt+Click), forwarded to the webview with the rest of the terminal settings, and applied to `terminal.options`.

This mirrors `xtermTerminal.ts`, which `TerminalConfigService`'s own header already cites as its reference — that file is exactly where VS Code wires these two settings into xterm.

Defaults are unchanged: `1` and `5`, matching both VS Code and the previous hardcoded values. Users who have not touched the setting see no difference.

## Tests

- `UnifiedConfigurationService.test.ts` — reads both keys from `terminal.integrated`; falls back to the VS Code defaults when unset
- `SettingsSyncService.test.ts` — both values are forwarded in the webview settings payload
- `UIManager.test.ts` — both are applied to `terminal.options`

The `UIManager` case was verified red against the unfixed code (`expected undefined to be 3`).

## Notes

Reading these from `terminal.integrated` rather than adding `secondaryTerminal.*` equivalents is deliberate: it follows the existing convention for Alt+Click, and it means one setting governs both terminals, which is what someone tuning scroll speed almost certainly wants. Happy to add extension-specific overrides on top if you'd prefer them configurable separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable mouse-wheel and fast-scroll sensitivity settings.
  * Applied sensitivity preferences to terminal scrolling.
  * Added default sensitivity values when no configuration is provided.

* **Bug Fixes**
  * Ensured scroll sensitivity settings are synchronized and applied consistently across the terminal interface.

* **Tests**
  * Added coverage for configured values, fallback defaults, synchronization, and terminal application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->