### PR TITLE
fix(find): only open terminal find on an unmodified Ctrl/Cmd+F

### DIFF
--- a/src/test/vitest/unit/webview/managers/FindInTerminalManager.test.ts
+++ b/src/test/vitest/unit/webview/managers/FindInTerminalManager.test.ts
@@ -273,6 +273,40 @@ describe('FindInTerminalManager', () => {
       expect(state.isVisible).toBe(true);
     });
 
+    // Cmd/Ctrl+Shift+F is Find in Files, and Cmd/Ctrl+Alt+F belongs to the
+    // workbench too - opening the terminal find panel steals both.
+    it.each([
+      ['Shift', { metaKey: true, shiftKey: true }],
+      ['Shift (uppercase key)', { metaKey: true, shiftKey: true, upper: true }],
+      ['Alt', { metaKey: true, altKey: true }],
+      ['Ctrl+Shift', { ctrlKey: true, shiftKey: true }],
+    ])('should ignore Cmd/Ctrl+%s+F', (_label, opts) => {
+      const { upper, ...modifiers } = opts as Record<string, boolean>;
+      const event = new KeyboardEvent('keydown', {
+        key: upper ? 'F' : 'f',
+        ...modifiers,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      document.dispatchEvent(event);
+
+      expect(manager.getSearchState().isVisible).toBe(false);
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('should open search on Cmd+F even when the key arrives uppercased', () => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'F',
+        metaKey: true,
+        bubbles: true,
+      });
+
+      document.dispatchEvent(event);
+
+      expect(manager.getSearchState().isVisible).toBe(true);
+    });
+
     it('should close search on Escape', () => {
       manager.showSearch();
 

--- a/src/webview/managers/FindInTerminalManager.ts
+++ b/src/webview/managers/FindInTerminalManager.ts
@@ -242,8 +242,17 @@ export class FindInTerminalManager implements IFindInTerminalManager {
    * Keyboard event handler for search shortcuts
    */
   private handleKeydown(event: KeyboardEvent): void {
-    // Ctrl+F / Cmd+F - Open search
-    if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
+    // Ctrl+F / Cmd+F - Open search.
+    // Shift and Alt must be excluded: those combinations belong to the
+    // workbench (Find in Files), and the key arrives lowercased on some
+    // platforms, so a bare `key === 'f'` swallows them.
+    const isFindShortcut =
+      (event.ctrlKey || event.metaKey) &&
+      !event.shiftKey &&
+      !event.altKey &&
+      event.key.toLowerCase() === 'f';
+
+    if (isFindShortcut) {
       event.preventDefault();
       this.showSearch();
       return;


### PR DESCRIPTION
## Current behavior

Pressing <kbd>Cmd/Ctrl+Shift+F</kbd> (Find in Files) while the sidebar terminal has focus opens the terminal's find panel on top of the workbench search. <kbd>Cmd/Ctrl+Alt+F</kbd> behaves the same way.

### Cause

`FindInTerminalManager.handleKeydown` matches on the modifier and the letter alone:

```ts
if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
  event.preventDefault();
  this.showSearch();
  return;
}
```

Nothing excludes Shift or Alt, so any `Ctrl/Cmd + <anything> + F` opens the panel and calls `preventDefault()` on its way through.

This depends on how the platform reports the letter. With Shift held the spec says `key` is `'F'`, in which case the condition happens to miss — but it arrives as `'f'` in the VS Code webview on macOS, which is why the shortcut is caught in practice. The two cases are covered separately in the tests below so the guard is correct either way.

## New behavior

The panel opens only when neither Shift nor Alt is held, and the letter is compared case-insensitively so the guard does not depend on platform casing:

```ts
const isFindShortcut =
  (event.ctrlKey || event.metaKey) &&
  !event.shiftKey &&
  !event.altKey &&
  event.key.toLowerCase() === 'f';
```

Plain <kbd>Cmd/Ctrl+F</kbd> is unchanged. Modified variants are left alone entirely — no `preventDefault()` — so they reach VS Code.

## Tests

In `FindInTerminalManager.test.ts`:

- `Cmd+Shift+F`, `Cmd+Alt+F` and `Ctrl+Shift+F` do not open the panel and do not cancel the event
- the same with the letter reported as `'F'`, so the guard holds under both casings
- `Cmd+F` still opens the panel, including when the letter arrives uppercased

Four of these were verified red against the unfixed handler.