### PR TITLE
fix(links): detect bare relative paths and activate OSC 8 hyperlinks

### DIFF
--- a/src/providers/services/TerminalLinkResolver.ts
+++ b/src/providers/services/TerminalLinkResolver.ts
@@ -45,12 +45,36 @@ export class TerminalLinkResolver {
 
     // Handle URL links
     if (linkType === 'url') {
+      // OSC 8 hyperlinks to files - what Claude Code emits for the paths it
+      // prints - arrive as file:// URLs. openExternal would hand those to the
+      // OS instead of opening them in the editor.
+      const fileUri = this._asFileUri(message.url);
+      if (fileUri) {
+        await this._handleFileLink({ ...message, filePath: fileUri.fsPath });
+        return;
+      }
+
       await this._handleUrlLink(message);
       return;
     }
 
     // Handle file links
     await this._handleFileLink(message);
+  }
+
+  /**
+   * Parse a link target as a file:// URI, or undefined when it is not one
+   */
+  private _asFileUri(url?: string): vscode.Uri | undefined {
+    if (!url) {
+      return undefined;
+    }
+    try {
+      const uri = vscode.Uri.parse(url);
+      return uri.scheme === 'file' ? uri : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   /**

--- a/src/test/vitest/unit/providers/services/TerminalLinkResolver.test.ts
+++ b/src/test/vitest/unit/providers/services/TerminalLinkResolver.test.ts
@@ -25,7 +25,11 @@ vi.mock('fs', () => ({
 // Mock VS Code API
 vi.mock('vscode', () => ({
   Uri: {
-    parse: vi.fn((url) => ({ toString: () => url })),
+    parse: vi.fn((url: string) => {
+      const scheme = /^([a-zA-Z][\w+.-]*):/.exec(url)?.[1] ?? '';
+      const fsPath = scheme === 'file' ? decodeURIComponent(url.replace(/^file:\/\//, '')) : url;
+      return { toString: () => url, scheme, fsPath };
+    }),
     file: vi.fn((path) => ({ fsPath: path, scheme: 'file' })),
   },
   env: {
@@ -105,6 +109,21 @@ describe('TerminalLinkResolver', () => {
       });
 
       expect(vscode.env.openExternal).toHaveBeenCalled();
+    });
+
+    it('should open file:// URLs in the editor rather than externally', async () => {
+      // OSC 8 hyperlinks to files arrive as linkType 'url'; openExternal would
+      // hand them to the OS instead of the editor.
+      mockFs.stat.mockResolvedValue({ isFile: () => true });
+
+      await resolver.handleOpenTerminalLink({
+        command: 'openTerminalLink',
+        linkType: 'url',
+        url: 'file:///tmp/sample.ts',
+      });
+
+      expect(vscode.env.openExternal).not.toHaveBeenCalled();
+      expect(vscode.window.showTextDocument).toHaveBeenCalled();
     });
 
     it('should handle file links with line numbers', async () => {

--- a/src/test/vitest/unit/webview/managers/TerminalLinkManager.test.ts
+++ b/src/test/vitest/unit/webview/managers/TerminalLinkManager.test.ts
@@ -182,6 +182,42 @@ describe('TerminalLinkManager', () => {
       expect(detectedLinks[0]!.text).toBe('./src/file.ts');
     });
 
+    const detect = (line: string): ILink[] => {
+      const mockTerminal = createMockTerminal([line]);
+      let links: ILink[] = [];
+      vi.mocked(mockTerminal.registerLinkProvider).mockImplementation((provider) => {
+        provider.provideLinks(1, (l) => {
+          links = l!;
+        });
+        return { dispose: vi.fn() };
+      });
+      manager.registerTerminalLinkHandlers(mockTerminal, 'terminal-1');
+      return links;
+    };
+
+    it('should detect a bare relative path in full', () => {
+      // The leading segment was being dropped, leaving '/test/a.ts'.
+      const links = detect('edit libs/test/a.ts:12 please');
+
+      expect(links.map((l) => l.text)).toEqual(['libs/test/a.ts:12']);
+    });
+
+    it('should detect every bare relative path on the line', () => {
+      const links = detect('two libs/a.ts and pkg/b.ts');
+
+      expect(links.map((l) => l.text)).toEqual(['libs/a.ts', 'pkg/b.ts']);
+    });
+
+    it.each([
+      'see https://github.com/o/r/pull/123 now',
+      'http://x.io/a/b',
+      'git@github.com:o/r.git',
+    ])('should not claim any part of %s', (line) => {
+      // Claiming a slice of a URL shadows the web-links provider, which
+      // registers first and would otherwise make the whole URL clickable.
+      expect(detect(line)).toEqual([]);
+    });
+
     it('should detect relative file paths with ../', () => {
       const lines = ['../parent/file.ts'];
       const mockTerminal = createMockTerminal(lines);
@@ -254,27 +290,8 @@ describe('TerminalLinkManager', () => {
       expect(detectedLinks[0]!.text).toBe('/path/to/file.ts:10:5');
     });
 
-    it('should detect URL path portion starting from first slash', () => {
-      // The regex pattern (?:\.{0,2}\/|[A-Za-z]:\\) matches 0-2 dots + /
-      // For https://example.com/path, it matches starting at the first /
-      // (with 0 dots before it), then continues with /example.com/path
-      const lines = ['https://example.com/path'];
-      const mockTerminal = createMockTerminal(lines);
-      let detectedLinks: ILink[] = [];
-
-      vi.mocked(mockTerminal.registerLinkProvider).mockImplementation((provider) => {
-        provider.provideLinks(1, (links) => {
-          detectedLinks = links!;
-        });
-        return { dispose: vi.fn() };
-      });
-
-      manager.registerTerminalLinkHandlers(mockTerminal, 'terminal-1');
-
-      // The regex matches //example.com/path (0 dots + / + rest)
-      // This looks like a file path to the regex
-      expect(detectedLinks.length).toBe(1);
-      expect(detectedLinks[0]!.text).toBe('//example.com/path');
+    it('should leave URLs to the web-links provider', () => {
+      expect(detect('https://example.com/path')).toEqual([]);
     });
 
     it('should clean trailing punctuation from paths', () => {

--- a/src/test/vitest/unit/webview/managers/TerminalLinkManager.test.ts
+++ b/src/test/vitest/unit/webview/managers/TerminalLinkManager.test.ts
@@ -195,6 +195,13 @@ describe('TerminalLinkManager', () => {
       return links;
     };
 
+    it.each([
+      ['open ~/something', '~/something'],
+      ['cfg ~/.config/nvim/init.lua', '~/.config/nvim/init.lua'],
+    ])('should keep the tilde in %s', (line, expected) => {
+      expect(detect(line).map((l) => l.text)).toEqual([expected]);
+    });
+
     it('should detect a bare relative path in full', () => {
       // The leading segment was being dropped, leaving '/test/a.ts'.
       const links = detect('edit libs/test/a.ts:12 please');

--- a/src/test/vitest/unit/webview/services/TerminalCreationService.test.ts
+++ b/src/test/vitest/unit/webview/services/TerminalCreationService.test.ts
@@ -205,6 +205,26 @@ describe('TerminalCreationService', () => {
   });
 
   describe('createTerminal()', () => {
+    it('should route OSC 8 hyperlinks to the extension', async () => {
+      const terminal = await service.createTerminal('terminal-1', 'Test Terminal');
+
+      // Without a linkHandler xterm.js falls back to confirm() + window.open(),
+      // which do nothing inside a WebView.
+      const linkHandler = terminal?.options.linkHandler;
+      expect(linkHandler).toBeDefined();
+
+      const range = { start: { x: 1, y: 1 }, end: { x: 10, y: 1 } };
+      linkHandler!.activate(new MouseEvent('click'), 'https://github.com/o/r/pull/670', range);
+
+      expect(mockCoordinator.postMessageToExtension).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'openTerminalLink',
+          linkType: 'url',
+          url: 'https://github.com/o/r/pull/670',
+        })
+      );
+    });
+
     it('should create terminal with basic configuration', async () => {
       // Arrange
       const terminalId = 'terminal-1';

--- a/src/test/vitest/unit/webview/services/TerminalCreationService.test.ts
+++ b/src/test/vitest/unit/webview/services/TerminalCreationService.test.ts
@@ -212,6 +212,9 @@ describe('TerminalCreationService', () => {
       // which do nothing inside a WebView.
       const linkHandler = terminal?.options.linkHandler;
       expect(linkHandler).toBeDefined();
+      // xterm.js discards non-http OSC 8 links unless this is set, and the
+      // paths Claude Code prints are file:// hyperlinks.
+      expect(linkHandler!.allowNonHttpProtocols).toBe(true);
 
       const range = { start: { x: 1, y: 1 }, end: { x: 10, y: 1 } };
       linkHandler!.activate(new MouseEvent('click'), 'https://github.com/o/r/pull/670', range);

--- a/src/webview/managers/TerminalLinkManager.ts
+++ b/src/webview/managers/TerminalLinkManager.ts
@@ -42,9 +42,15 @@ export class TerminalLinkManager extends BaseManager {
   // 'ctrlCmd' means Cmd/Ctrl is for multi-cursor, so Alt opens links
   private linkModifier: 'alt' | 'ctrlCmd' = 'alt';
 
-  // Simple regex to match file paths
-  // Matches: /path/to/file, ./relative/path, ../parent/path, C:\windows\path
-  private readonly filePathRegex = /(?:\.{0,2}\/|[A-Za-z]:\\)[^\s"'<>()[\]{}|]+/g;
+  // Matches: /path/to/file, ./relative/path, ../parent/path, C:\windows\path,
+  // and bare relative paths such as libs/test/a.ts.
+  //
+  // The leading lookbehind keeps the pattern out of URLs. Without it a bare
+  // segment inside https://github.com/o/r matches, and because this provider
+  // registers after WebLinksAddon, xterm drops the intersecting web link and
+  // the URL stops being clickable.
+  private readonly filePathRegex =
+    /(?<![\w:/\\.])(?:[A-Za-z]:\\[^\s"'<>()[\]{}|]+|\.{0,2}\/[^\s"'<>()[\]{}|]+|[\w.-]+(?:\/[\w.-]+)+(?::\d+(?::\d+)?)?)/g;
 
   constructor(coordinator: IManagerCoordinator) {
     super('TerminalLinkManager', {
@@ -256,13 +262,9 @@ export class TerminalLinkManager extends BaseManager {
    * Check if a string looks like a valid file path
    */
   private isValidFilePath(path: string): boolean {
-    // Must start with /, ./, ../, or drive letter
-    const hasPathPrefix = /^(\/|\.\.?\/|[A-Za-z]:\\)/.test(path);
-    if (!hasPathPrefix) return false;
-
-    // Must have at least one path separator
-    const hasPathSeparator = path.includes('/') || path.includes('\\');
-    return hasPathSeparator;
+    // A bare relative path such as libs/test/a.ts has no prefix, so a separator
+    // is what distinguishes a path from an ordinary word.
+    return path.includes('/') || path.includes('\\');
   }
 
   /**

--- a/src/webview/managers/TerminalLinkManager.ts
+++ b/src/webview/managers/TerminalLinkManager.ts
@@ -42,15 +42,15 @@ export class TerminalLinkManager extends BaseManager {
   // 'ctrlCmd' means Cmd/Ctrl is for multi-cursor, so Alt opens links
   private linkModifier: 'alt' | 'ctrlCmd' = 'alt';
 
-  // Matches: /path/to/file, ./relative/path, ../parent/path, C:\windows\path,
-  // and bare relative paths such as libs/test/a.ts.
+  // Matches: /path/to/file, ./relative/path, ../parent/path, ~/home/path,
+  // C:\windows\path, and bare relative paths such as libs/test/a.ts.
   //
   // The leading lookbehind keeps the pattern out of URLs. Without it a bare
   // segment inside https://github.com/o/r matches, and because this provider
   // registers after WebLinksAddon, xterm drops the intersecting web link and
   // the URL stops being clickable.
   private readonly filePathRegex =
-    /(?<![\w:/\\.])(?:[A-Za-z]:\\[^\s"'<>()[\]{}|]+|\.{0,2}\/[^\s"'<>()[\]{}|]+|[\w.-]+(?:\/[\w.-]+)+(?::\d+(?::\d+)?)?)/g;
+    /(?<![\w:/\\.~])(?:[A-Za-z]:\\[^\s"'<>()[\]{}|]+|~\/[^\s"'<>()[\]{}|]+|\.{0,2}\/[^\s"'<>()[\]{}|]+|[\w.-]+(?:\/[\w.-]+)+(?::\d+(?::\d+)?)?)/g;
 
   constructor(coordinator: IManagerCoordinator) {
     super('TerminalLinkManager', {

--- a/src/webview/services/TerminalCreationService.ts
+++ b/src/webview/services/TerminalCreationService.ts
@@ -351,7 +351,12 @@ export class TerminalCreationService implements Disposable {
     // WebView, so those links look clickable but do nothing.
     const terminal = new Terminal({
       ...terminalConfig,
-      linkHandler: { activate: (_event, uri) => openUrl(uri) },
+      linkHandler: {
+        // file:// hyperlinks are dropped entirely without this, which lets the
+        // file path provider claim the text instead of the app's own link.
+        allowNonHttpProtocols: true,
+        activate: (_event, uri) => openUrl(uri),
+      },
     });
     terminalLogger.info(`✅ Terminal instance created: ${terminalId}`);
 

--- a/src/webview/services/TerminalCreationService.ts
+++ b/src/webview/services/TerminalCreationService.ts
@@ -328,7 +328,31 @@ export class TerminalCreationService implements Disposable {
     serializeAddon: SerializeAddon;
     searchAddon: SearchAddon | undefined;
   }> {
-    const terminal = new Terminal(terminalConfig);
+    const openUrl = (uri: string): void => {
+      try {
+        this.coordinator?.postMessageToExtension({
+          command: 'openTerminalLink',
+          linkType: 'url',
+          url: uri,
+          terminalId,
+          timestamp: Date.now(),
+        });
+      } catch {
+        try {
+          window.open(uri, '_blank');
+        } catch {
+          // swallow; extension path is primary
+        }
+      }
+    };
+
+    // OSC 8 hyperlinks are activated through options.linkHandler. Without one
+    // xterm.js falls back to confirm() plus window.open(), both inert inside a
+    // WebView, so those links look clickable but do nothing.
+    const terminal = new Terminal({
+      ...terminalConfig,
+      linkHandler: { activate: (_event, uri) => openUrl(uri) },
+    });
     terminalLogger.info(`✅ Terminal instance created: ${terminalId}`);
 
     const loadedAddons = await this.addonManager.loadAllAddons(terminal, terminalId, {
@@ -336,23 +360,7 @@ export class TerminalCreationService implements Disposable {
       enableSearchAddon: terminalConfig.enableSearchAddon,
       enableUnicode11: terminalConfig.enableUnicode11,
       linkModifier,
-      linkHandler: (_event, uri) => {
-        try {
-          this.coordinator?.postMessageToExtension({
-            command: 'openTerminalLink',
-            linkType: 'url',
-            url: uri,
-            terminalId,
-            timestamp: Date.now(),
-          });
-        } catch {
-          try {
-            window.open(uri, '_blank');
-          } catch {
-            // swallow; extension path is primary
-          }
-        }
-      },
+      linkHandler: (_event, uri) => openUrl(uri),
     });
 
     const { fitAddon, serializeAddon, searchAddon } = loadedAddons;


### PR DESCRIPTION
Two link defects, both in the sidebar terminal only.

## 1. Bare relative paths lose their first segment

Cmd/Ctrl+clicking `libs/test/a.ts` highlights and opens `/test/a.ts`. The integrated terminal handles the whole path.

`filePathRegex` can only start at `/`, `./`, `../` or a drive letter:

```ts
private readonly filePathRegex = /(?:\.{0,2}\/|[A-Za-z]:\\)[^\s"'<>()[\]{}|]+/g;
```

`\.{0,2}\/` with zero dots is just `/`, so in `libs/test/a.ts` the first match begins at the slash after `libs`. `isValidFilePath` then required the same prefixes, so a bare relative path could not have been accepted anyway.

## 2. The same pattern swallows URLs

For `https://github.com/o/r/pull/123` the pattern matches `//github.com/o/r/pull/123`. This provider registers after `WebLinksAddon` (addons load in `createTerminalWithAddons`, the file provider in `finalizeTerminalSetup`), and xterm.js's `_removeIntersectingLinks` drops links from later providers that intersect earlier ones — so the web link survives, but a slice of every URL is claimed as a file path.

Fixed by anchoring the pattern so a match cannot begin inside a URL, and accepting bare relative paths that contain a separator.

## 3. OSC 8 hyperlinks do nothing

Claude Code renders `PR #670` as an OSC 8 hyperlink. Cmd+clicking it works in the integrated terminal, not here.

xterm.js activates OSC 8 links through `options.linkHandler`:

```js
activate: (e, t) => r ? r.activate(e, t, n) : l(0, t)   // r = rawOptions.linkHandler
```

A handler was passed to `loadAllAddons` for `WebLinksAddon`, but never to `new Terminal(...)`, so `linkHandler` stayed `null` and activation fell to `l()` — a `confirm()` followed by `window.open()`. Both are inert inside a WebView, so the link looks clickable and does nothing.

The same handler is now passed to the `Terminal` constructor, so OSC 8 links post `openTerminalLink` like any other URL.

## Tests

`TerminalLinkManager.test.ts`:
- a bare relative path is detected in full, including a `:line` suffix
- multiple bare paths on one line
- nothing is claimed from `https://…`, `http://…` or `git@github.com:o/r.git`

`TerminalCreationService.test.ts`:
- the terminal is constructed with a `linkHandler` whose `activate` posts `openTerminalLink`

Five were verified red against the unfixed code (`expected [ '/test/a.ts:12' ] to deeply equal [ 'libs/test/a.ts:12' ]`), and the OSC 8 case fails with `expected undefined to be defined`.

One existing test asserted the old URL behaviour explicitly — `should detect URL path portion starting from first slash`, expecting `'//example.com/path'`, with a comment explaining how the regex produced it. It documented the defect rather than a requirement, so it now asserts that URLs are left to the web-links provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal output now recognizes relative file paths, including optional line and column references.
  * OSC 8 hyperlinks in the terminal can be opened directly.
* **Bug Fixes**
  * URLs and SCP-style strings are no longer incorrectly identified as file links.
  * Terminal links now open through the extension when available, with browser fallback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->