### PR TITLE
fix(find): scope Ctrl/Cmd+F to the focused terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,11 @@
         "icon": "$(add)"
       },
       {
+        "command": "secondaryTerminal.focusFind",
+        "title": "Find in Terminal",
+        "category": "Secondary Terminal"
+      },
+      {
         "command": "secondaryTerminal.clearTerminal",
         "title": "Clear Terminal",
         "category": "Secondary Terminal",
@@ -971,6 +976,12 @@
         "command": "secondaryTerminal.killTerminal",
         "key": "ctrl+shift+x",
         "mac": "cmd+shift+x",
+        "when": "secondaryTerminalFocus"
+      },
+      {
+        "command": "secondaryTerminal.focusFind",
+        "key": "ctrl+f",
+        "mac": "cmd+f",
         "when": "secondaryTerminalFocus"
       },
       {

--- a/package.json
+++ b/package.json
@@ -982,7 +982,7 @@
         "command": "secondaryTerminal.focusFind",
         "key": "ctrl+f",
         "mac": "cmd+f",
-        "when": "secondaryTerminalFocus || focusedView == 'secondaryTerminal'"
+        "when": "secondaryTerminalFocus"
       },
       {
         "command": "secondaryTerminal.clearTerminal",

--- a/package.json
+++ b/package.json
@@ -982,7 +982,7 @@
         "command": "secondaryTerminal.focusFind",
         "key": "ctrl+f",
         "mac": "cmd+f",
-        "when": "secondaryTerminalFocus"
+        "when": "secondaryTerminalFocus || focusedView == 'secondaryTerminal'"
       },
       {
         "command": "secondaryTerminal.clearTerminal",

--- a/src/services/KeyboardShortcutService.ts
+++ b/src/services/KeyboardShortcutService.ts
@@ -138,6 +138,11 @@ export class KeyboardShortcutService {
     );
 
     // Search Operations - Note: 'secondaryTerminal.find' is registered in ExtensionLifecycle.ts
+    this._disposables.add(
+      vscode.commands.registerCommand('secondaryTerminal.focusFind', () => {
+        this.focusFind();
+      })
+    );
 
     this._disposables.add(
       vscode.commands.registerCommand('secondaryTerminal.runRecentCommand', () => {
@@ -363,6 +368,17 @@ export class KeyboardShortcutService {
 
   /**
    * Open find box (VS Code standard: Ctrl+F)
+   */
+  public focusFind(): void {
+    const activeTerminal = this._terminalManager.getActiveTerminalId();
+    if (!activeTerminal) return;
+
+    this.sendWebviewCommand('focusFind', { terminalId: activeTerminal });
+    log(`🔍 [KEYBOARD] Opened find panel for: ${activeTerminal}`);
+  }
+
+  /**
+   * Prompt for a search term and search the terminal
    */
   public async find(): Promise<void> {
     const activeTerminal = this._terminalManager.getActiveTerminalId();

--- a/src/test/vitest/unit/webview/managers/ConsolidatedMessageManager.test.ts
+++ b/src/test/vitest/unit/webview/managers/ConsolidatedMessageManager.test.ts
@@ -89,6 +89,17 @@ describe('ConsolidatedMessageManager', () => {
   });
 
   describe('Message Routing', () => {
+    it('should route every command the shell integration handler declares', async () => {
+      // The dispatcher used to keep its own hardcoded list, so commands the
+      // handler supported were dropped before reaching it.
+      const showSearch = vi.fn();
+      const coordinator = { ...mockCoordinator, findInTerminalManager: { showSearch } } as never;
+
+      await messageManager.receiveMessage({ command: 'focusFind' } as never, coordinator);
+
+      expect(showSearch).toHaveBeenCalled();
+    });
+
     it('should handle init message', async () => {
       const message: MessageCommand = {
         command: 'init',

--- a/src/test/vitest/unit/webview/managers/FindInTerminalManager.test.ts
+++ b/src/test/vitest/unit/webview/managers/FindInTerminalManager.test.ts
@@ -247,30 +247,25 @@ describe('FindInTerminalManager', () => {
   });
 
   describe('keyboard shortcuts', () => {
-    it('should open search on Ctrl+F', () => {
+    // Ctrl/Cmd+F arrives as the contributed secondaryTerminal.focusFind
+    // keybinding, scoped to secondaryTerminalFocus. Handling it here as well
+    // opened this panel on top of the workbench find widget, because a WebView
+    // cannot stop VS Code from resolving the chord itself.
+    it.each([
+      ['Ctrl+F', { ctrlKey: true }],
+      ['Cmd+F', { metaKey: true }],
+    ])('should not open search on %s', (_label, modifiers) => {
       const event = new KeyboardEvent('keydown', {
         key: 'f',
-        ctrlKey: true,
+        ...modifiers,
         bubbles: true,
+        cancelable: true,
       });
 
       document.dispatchEvent(event);
 
-      const state = manager.getSearchState();
-      expect(state.isVisible).toBe(true);
-    });
-
-    it('should open search on Cmd+F (Mac)', () => {
-      const event = new KeyboardEvent('keydown', {
-        key: 'f',
-        metaKey: true,
-        bubbles: true,
-      });
-
-      document.dispatchEvent(event);
-
-      const state = manager.getSearchState();
-      expect(state.isVisible).toBe(true);
+      expect(manager.getSearchState().isVisible).toBe(false);
+      expect(event.defaultPrevented).toBe(false);
     });
 
     it('should close search on Escape', () => {

--- a/src/test/vitest/unit/webview/managers/handlers/ShellIntegrationMessageHandler.test.ts
+++ b/src/test/vitest/unit/webview/managers/handlers/ShellIntegrationMessageHandler.test.ts
@@ -96,6 +96,26 @@ describe('ShellIntegrationMessageHandler', () => {
     });
   });
 
+  describe('Find Panel', () => {
+    it('opens the find panel for the focusFind command', () => {
+      const showSearch = vi.fn();
+      const coordinator = { ...mockCoordinator, findInTerminalManager: { showSearch } } as never;
+
+      handler.handleMessage(
+        { command: 'focusFind', terminalId: 'terminal-1' } as never,
+        coordinator
+      );
+
+      expect(showSearch).toHaveBeenCalled();
+    });
+
+    it('does not throw when no find manager is present', () => {
+      expect(() =>
+        handler.handleMessage({ command: 'focusFind' } as never, mockCoordinator)
+      ).not.toThrow();
+    });
+  });
+
   describe('Shell Status Handling', () => {
     it('should handle shellStatus message', () => {
       const message: MessageCommand = {

--- a/src/webview/managers/ConsolidatedMessageManager.ts
+++ b/src/webview/managers/ConsolidatedMessageManager.ts
@@ -222,7 +222,9 @@ export class ConsolidatedMessageManager implements IMessageManager {
     );
 
     // Shell Integration Messages
-    const shellIntegrationCommands = ['shellStatus', 'cwdUpdate', 'commandHistory', 'find'];
+    // Taken from the handler so its registry stays the single source of truth;
+    // a second hardcoded list here silently drops commands it does not know.
+    const shellIntegrationCommands = this.shellIntegrationHandler.getSupportedCommands();
     shellIntegrationCommands.forEach((cmd) =>
       registry.set(cmd, (msg, coord) => this.shellIntegrationHandler.handleMessage(msg, coord))
     );

--- a/src/webview/managers/FindInTerminalManager.ts
+++ b/src/webview/managers/FindInTerminalManager.ts
@@ -242,13 +242,6 @@ export class FindInTerminalManager implements IFindInTerminalManager {
    * Keyboard event handler for search shortcuts
    */
   private handleKeydown(event: KeyboardEvent): void {
-    // Ctrl+F / Cmd+F - Open search
-    if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
-      event.preventDefault();
-      this.showSearch();
-      return;
-    }
-
     // Escape - Close search
     if (event.key === 'Escape' && this.isSearchVisible) {
       event.preventDefault();

--- a/src/webview/managers/handlers/ShellIntegrationMessageHandler.ts
+++ b/src/webview/managers/handlers/ShellIntegrationMessageHandler.ts
@@ -50,6 +50,7 @@ export class ShellIntegrationMessageHandler implements IMessageHandler {
     registry.set('cwdUpdate', (msg, coord) => this.handleCwdUpdate(msg, coord));
     registry.set('commandHistory', (msg, coord) => this.handleCommandHistory(msg, coord));
     registry.set('find', (msg, coord) => this.handleFind(msg, coord));
+    registry.set('focusFind', (_msg, coord) => coord.findInTerminalManager?.showSearch());
 
     return registry;
   }


### PR DESCRIPTION
## Current behavior

Pressing <kbd>Ctrl/Cmd+F</kbd> with the sidebar terminal focused opens the terminal find panel **and** the workbench find widget at the same time.

### Cause

The shortcut was handled entirely inside the WebView, from a `document` keydown listener in `FindInTerminalManager`:

```ts
if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
  event.preventDefault();
  this.showSearch();
  return;
}
```

`preventDefault()` cannot help here. VS Code forwards WebView keydown events to the workbench for keybinding resolution regardless, so both handlers run.

Every other terminal shortcut in this extension avoids that by being a contributed keybinding scoped with `when: secondaryTerminalFocus` — `clearTerminal`, `selectAll`, `copy`, `splitTerminal` and the rest. `Ctrl/Cmd+F` was the one that never got a contribution, so VS Code had no reason to route it anywhere but its own find.

## New behavior

`secondaryTerminal.focusFind` is contributed with `"key": "ctrl+f"`, `"mac": "cmd+f"`, `"when": "secondaryTerminalFocus"`. VS Code now resolves the chord to exactly one handler based on focus: the terminal panel when the terminal is focused, its own find widget otherwise.

The command sends a `focusFind` message to the WebView, which opens the same `FindInTerminalManager` panel as before, so the UI is unchanged. The local keydown branch is removed; `Escape` and `F3`/`Shift+F3` still work as they did, since those only act while the panel is open.

## Tests

- `FindInTerminalManager.test.ts` — `Ctrl+F` and `Cmd+F` no longer open the panel from a document keydown and no longer cancel the event. The two tests that asserted the old local handling are replaced, since that behaviour is what caused the double open.
- `ShellIntegrationMessageHandler.test.ts` — the `focusFind` message opens the panel, and is a no-op when no find manager is present.

Both `FindInTerminalManager` cases were verified red against the unfixed manager.

## Note

`secondaryTerminal.find` already existed (registered in `ExtensionLifecycle.ts`) but prompts for a search term through `showInputBox` — a different flow from the in-terminal panel. It is left untouched; this adds `focusFind` alongside it rather than changing what `find` does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Ctrl+F/Cmd+F shortcuts to open search in the focused secondary terminal.
  - Added a terminal find command and title for easier search access.

- **Bug Fixes**
  - Prevented terminal search shortcuts from interfering with standard browser keyboard behavior.
  - Search commands now safely handle cases where no terminal or search panel is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->