### PR TITLE
fix(scrolling): honour scroll sensitivity and let xterm encode wheel reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -456,6 +456,11 @@
           "default": true,
           "description": "Enable file reference shortcuts: Use Cmd+Option+L (Mac) or Alt+Ctrl+L (Linux/Windows) to insert file references"
         },
+        "secondaryTerminal.legacyMouseWheelEncoding": {
+          "type": "boolean",
+          "default": false,
+          "description": "Encode mouse-tracking wheel events in the WebView instead of letting xterm.js do it. The WebView encoder ignores scroll sensitivity and pixel-precise trackpad deltas; enable only if wheel scrolling stops working in full-screen apps such as vim, tmux or zellij."
+        },
         "secondaryTerminal.focusProtection": {
           "type": "boolean",
           "default": true,

--- a/src/config/UnifiedConfigurationService.ts
+++ b/src/config/UnifiedConfigurationService.ts
@@ -460,6 +460,31 @@ export class UnifiedConfigurationService implements Disposable {
   }
 
   /**
+   * Get scroll sensitivity settings (VS Code standard)
+   *
+   * Mirrors xtermTerminal.ts, which feeds these into xterm.js as
+   * scrollSensitivity / fastScrollSensitivity.
+   */
+  public getScrollSensitivitySettings(): {
+    scrollSensitivity: number;
+    fastScrollSensitivity: number;
+  } {
+    this.initialize();
+    return {
+      scrollSensitivity: this.get(
+        CONFIG_SECTIONS.TERMINAL_INTEGRATED,
+        CONFIG_KEYS.MOUSE_WHEEL_SCROLL_SENSITIVITY,
+        1
+      ),
+      fastScrollSensitivity: this.get(
+        CONFIG_SECTIONS.TERMINAL_INTEGRATED,
+        CONFIG_KEYS.FAST_SCROLL_SENSITIVITY,
+        5
+      ),
+    };
+  }
+
+  /**
    * Get font family with VS Code hierarchy
    * Priority: secondaryTerminal.fontFamily > terminal.integrated.fontFamily > editor.fontFamily > system default
    */

--- a/src/providers/services/SettingsSyncService.ts
+++ b/src/providers/services/SettingsSyncService.ts
@@ -74,6 +74,7 @@ export class SettingsSyncService {
     const configService = getUnifiedConfigurationService();
     const settings = configService.getCompleteTerminalSettings();
     const altClickSettings = configService.getAltClickSettings();
+    const scrollSettings = configService.getScrollSensitivitySettings();
 
     // Use unified service for all configuration access
     return {
@@ -81,6 +82,9 @@ export class SettingsSyncService {
       theme: settings.theme || 'auto',
       // Scrollback buffer size (secondaryTerminal.scrollback setting)
       scrollback: configService.get('secondaryTerminal', 'scrollback', 2000),
+      // Scroll speed, shared with the integrated terminal
+      scrollSensitivity: scrollSettings.scrollSensitivity,
+      fastScrollSensitivity: scrollSettings.fastScrollSensitivity,
       // VS Code standard settings for Alt+Click functionality
       altClickMovesCursor: altClickSettings.altClickMovesCursor,
       multiCursorModifier: altClickSettings.multiCursorModifier,

--- a/src/providers/services/SettingsSyncService.ts
+++ b/src/providers/services/SettingsSyncService.ts
@@ -85,6 +85,11 @@ export class SettingsSyncService {
       // Scroll speed, shared with the integrated terminal
       scrollSensitivity: scrollSettings.scrollSensitivity,
       fastScrollSensitivity: scrollSettings.fastScrollSensitivity,
+      legacyMouseWheelEncoding: configService.get(
+        'secondaryTerminal',
+        'legacyMouseWheelEncoding',
+        false
+      ),
       // VS Code standard settings for Alt+Click functionality
       altClickMovesCursor: altClickSettings.altClickMovesCursor,
       multiCursorModifier: altClickSettings.multiCursorModifier,

--- a/src/test/vitest/unit/config/UnifiedConfigurationService.test.ts
+++ b/src/test/vitest/unit/config/UnifiedConfigurationService.test.ts
@@ -574,6 +574,38 @@ describe('UnifiedConfigurationService', () => {
     });
   });
 
+  describe('Scroll Sensitivity Configuration', () => {
+    const stubTerminalIntegrated = (values: Record<string, number>) => {
+      const terminalIntegratedConfig = {
+        get: vi.fn((key: string, def: unknown) => values[key] ?? def),
+      };
+      (vscode.workspace.getConfiguration as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        (section?: string) =>
+          section === CONFIG_SECTIONS.TERMINAL_INTEGRATED
+            ? terminalIntegratedConfig
+            : mockWorkspaceConfiguration
+      );
+    };
+
+    it('should read sensitivity from terminal.integrated', () => {
+      stubTerminalIntegrated({ mouseWheelScrollSensitivity: 3, fastScrollSensitivity: 8 });
+
+      expect(service.getScrollSensitivitySettings()).toEqual({
+        scrollSensitivity: 3,
+        fastScrollSensitivity: 8,
+      });
+    });
+
+    it('should fall back to the VS Code defaults', () => {
+      stubTerminalIntegrated({});
+
+      expect(service.getScrollSensitivitySettings()).toEqual({
+        scrollSensitivity: 1,
+        fastScrollSensitivity: 5,
+      });
+    });
+  });
+
   describe('Alt+Click Configuration', () => {
     it('should get Alt+Click settings', () => {
       const terminalIntegratedConfig = { get: vi.fn() };

--- a/src/test/vitest/unit/providers/services/SettingsSyncService.test.ts
+++ b/src/test/vitest/unit/providers/services/SettingsSyncService.test.ts
@@ -136,6 +136,7 @@ describe('SettingsSyncService', () => {
         fastScrollSensitivity: 5,
       });
       mockUnifiedConfig.get.mockImplementation((section, key, def) => {
+        if (key === 'legacyMouseWheelEncoding') return false;
         if (key === 'scrollback') return 5000;
         if (key === 'activeBorderMode') return 'all';
         if (key === 'panelLocation') return 'sidebar';
@@ -156,6 +157,7 @@ describe('SettingsSyncService', () => {
         scrollback: 5000,
         scrollSensitivity: 3,
         fastScrollSensitivity: 5,
+        legacyMouseWheelEncoding: false,
         altClickMovesCursor: true,
         multiCursorModifier: 'alt',
         enableCliAgentIntegration: true,
@@ -208,6 +210,18 @@ describe('SettingsSyncService', () => {
 
       expect(settings.scrollSensitivity).toBe(7);
       expect(settings.fastScrollSensitivity).toBe(9);
+    });
+
+    it('forwards the legacy wheel encoding opt-in', () => {
+      mockUnifiedConfig.getCompleteTerminalSettings.mockReturnValue({});
+      mockUnifiedConfig.getAltClickSettings.mockReturnValue({});
+      mockUnifiedConfig.getScrollSensitivitySettings.mockReturnValue({});
+      mockUnifiedConfig.isFeatureEnabled.mockReturnValue(false);
+      mockUnifiedConfig.get.mockImplementation((_section, key, def) =>
+        key === 'legacyMouseWheelEncoding' ? true : def
+      );
+
+      expect(service.getCurrentSettings().legacyMouseWheelEncoding).toBe(true);
     });
   });
 

--- a/src/test/vitest/unit/providers/services/SettingsSyncService.test.ts
+++ b/src/test/vitest/unit/providers/services/SettingsSyncService.test.ts
@@ -17,6 +17,7 @@ const { mockUnifiedConfig } = vi.hoisted(() => ({
     update: vi.fn().mockResolvedValue(undefined),
     isFeatureEnabled: vi.fn(),
     getAltClickSettings: vi.fn(),
+    getScrollSensitivitySettings: vi.fn(),
   },
 }));
 
@@ -130,6 +131,10 @@ describe('SettingsSyncService', () => {
         altClickMovesCursor: true,
         multiCursorModifier: 'alt',
       });
+      mockUnifiedConfig.getScrollSensitivitySettings.mockReturnValue({
+        scrollSensitivity: 3,
+        fastScrollSensitivity: 5,
+      });
       mockUnifiedConfig.get.mockImplementation((section, key, def) => {
         if (key === 'scrollback') return 5000;
         if (key === 'activeBorderMode') return 'all';
@@ -149,6 +154,8 @@ describe('SettingsSyncService', () => {
         cursorBlink: true,
         theme: 'dark',
         scrollback: 5000,
+        scrollSensitivity: 3,
+        fastScrollSensitivity: 5,
         altClickMovesCursor: true,
         multiCursorModifier: 'alt',
         enableCliAgentIntegration: true,
@@ -166,6 +173,10 @@ describe('SettingsSyncService', () => {
     it('should forward VS Code keybinding settings to the WebView', () => {
       mockUnifiedConfig.getCompleteTerminalSettings.mockReturnValue({});
       mockUnifiedConfig.getAltClickSettings.mockReturnValue({});
+      mockUnifiedConfig.getScrollSensitivitySettings.mockReturnValue({
+        scrollSensitivity: 1,
+        fastScrollSensitivity: 5,
+      });
       mockUnifiedConfig.isFeatureEnabled.mockReturnValue(false);
       mockUnifiedConfig.get.mockImplementation((section, key, def) => {
         if (key === 'sendKeybindingsToShell') return true;
@@ -181,6 +192,22 @@ describe('SettingsSyncService', () => {
       expect(settings.commandsToSkipShell).toEqual(['-workbench.action.terminal.moveToLineStart']);
       expect(settings.allowChords).toBe(false);
       expect(settings.allowMnemonics).toBe(false);
+    });
+
+    it('forwards scroll sensitivity so the sidebar scrolls like the integrated terminal', () => {
+      mockUnifiedConfig.getCompleteTerminalSettings.mockReturnValue({});
+      mockUnifiedConfig.getAltClickSettings.mockReturnValue({});
+      mockUnifiedConfig.get.mockImplementation((_section, _key, def) => def);
+      mockUnifiedConfig.isFeatureEnabled.mockReturnValue(false);
+      mockUnifiedConfig.getScrollSensitivitySettings.mockReturnValue({
+        scrollSensitivity: 7,
+        fastScrollSensitivity: 9,
+      });
+
+      const settings = service.getCurrentSettings();
+
+      expect(settings.scrollSensitivity).toBe(7);
+      expect(settings.fastScrollSensitivity).toBe(9);
     });
   });
 

--- a/src/test/vitest/unit/webview/managers/UIManager.test.ts
+++ b/src/test/vitest/unit/webview/managers/UIManager.test.ts
@@ -343,6 +343,23 @@ describe('UIManager', () => {
       expect(mockTerminal.options.scrollback).toBe(1000);
     });
 
+    it('should apply scroll sensitivity from settings', () => {
+      const mockTerminal = {
+        options: {},
+        refresh: vi.fn(),
+        rows: 24,
+        element: document.createElement('div'),
+      } as any;
+
+      uiManager.applyAllVisualSettings(mockTerminal, {
+        scrollSensitivity: 3,
+        fastScrollSensitivity: 8,
+      });
+
+      expect(mockTerminal.options.scrollSensitivity).toBe(3);
+      expect(mockTerminal.options.fastScrollSensitivity).toBe(8);
+    });
+
     it('should apply cursor blink from settings.cursorBlink', () => {
       const mockTerminal = {
         options: {},

--- a/src/test/vitest/unit/webview/services/terminal/MouseTrackingService.test.ts
+++ b/src/test/vitest/unit/webview/services/terminal/MouseTrackingService.test.ts
@@ -221,16 +221,14 @@ describe('MouseTrackingService', () => {
   });
 
   describe('wheel event handling', () => {
-    beforeEach(() => {
+    // xterm.js encodes wheel reports itself, applying scroll sensitivity and
+    // accumulating pixel deltas into whole lines. The handler below does none
+    // of that, so it is off unless explicitly opted into.
+    it('does not intercept the wheel by default', () => {
       service.setup(mockTerminal as any, 't1', viewport, mockSendInput);
-      // Enable mouse mode to activate wheel handler
       mockTerminal._simulateCsi('h', [1006]);
-    });
 
-    it('should send SGR escape sequence on wheel down', () => {
       const screenElement = mockTerminal.element.querySelector('.xterm-screen')!;
-
-      // Simulate wheel event (happy-dom doesn't populate clientX/Y from constructor)
       const wheelEvent = new WheelEvent('wheel', {
         deltaY: 100,
         bubbles: true,
@@ -240,31 +238,60 @@ describe('MouseTrackingService', () => {
       Object.defineProperty(wheelEvent, 'clientY', { value: 50 });
       screenElement.dispatchEvent(wheelEvent);
 
-      // Should call sendInput with SGR wheel down sequence (button 65)
-      expect(mockSendInput).toHaveBeenCalled();
-      const call = (mockSendInput as any).mock.calls[0];
-      expect(call[0]).toBe('t1');
-      expect(call[1]).toMatch(/\x1b\[<65;\d+;\d+M/);
+      expect(mockSendInput).not.toHaveBeenCalled();
+      expect(wheelEvent.defaultPrevented).toBe(false);
+      // Native scrolling still has to be off, or the viewport scrolls itself
+      // instead of the sequence reaching the app.
+      expect(viewport.style.overflow).toBe('hidden');
     });
 
-    it('should send SGR escape sequence on wheel up', () => {
-      const screenElement = mockTerminal.element.querySelector('.xterm-screen')!;
-
-      // Simulate wheel event (happy-dom doesn't populate clientX/Y from constructor)
-      const wheelEvent = new WheelEvent('wheel', {
-        deltaY: -100,
-        bubbles: true,
-        cancelable: true,
+    describe('when legacy encoding is enabled', () => {
+      beforeEach(() => {
+        service = new MouseTrackingService(() => true);
+        service.setup(mockTerminal as any, 't1', viewport, mockSendInput);
+        // Enable mouse mode to activate wheel handler
+        mockTerminal._simulateCsi('h', [1006]);
       });
-      Object.defineProperty(wheelEvent, 'clientX', { value: 50 });
-      Object.defineProperty(wheelEvent, 'clientY', { value: 50 });
-      screenElement.dispatchEvent(wheelEvent);
 
-      // Should call sendInput with SGR wheel up sequence (button 64)
-      expect(mockSendInput).toHaveBeenCalled();
-      const call = (mockSendInput as any).mock.calls[0];
-      expect(call[0]).toBe('t1');
-      expect(call[1]).toMatch(/\x1b\[<64;\d+;\d+M/);
+      it('should send SGR escape sequence on wheel down', () => {
+        const screenElement = mockTerminal.element.querySelector('.xterm-screen')!;
+
+        // Simulate wheel event (happy-dom doesn't populate clientX/Y from constructor)
+        const wheelEvent = new WheelEvent('wheel', {
+          deltaY: 100,
+          bubbles: true,
+          cancelable: true,
+        });
+        Object.defineProperty(wheelEvent, 'clientX', { value: 50 });
+        Object.defineProperty(wheelEvent, 'clientY', { value: 50 });
+        screenElement.dispatchEvent(wheelEvent);
+
+        // Should call sendInput with SGR wheel down sequence (button 65)
+        expect(mockSendInput).toHaveBeenCalled();
+        const call = (mockSendInput as any).mock.calls[0];
+        expect(call[0]).toBe('t1');
+        expect(call[1]).toMatch(/\x1b\[<65;\d+;\d+M/);
+      });
+
+      it('should send SGR escape sequence on wheel up', () => {
+        const screenElement = mockTerminal.element.querySelector('.xterm-screen')!;
+
+        // Simulate wheel event (happy-dom doesn't populate clientX/Y from constructor)
+        const wheelEvent = new WheelEvent('wheel', {
+          deltaY: -100,
+          bubbles: true,
+          cancelable: true,
+        });
+        Object.defineProperty(wheelEvent, 'clientX', { value: 50 });
+        Object.defineProperty(wheelEvent, 'clientY', { value: 50 });
+        screenElement.dispatchEvent(wheelEvent);
+
+        // Should call sendInput with SGR wheel up sequence (button 64)
+        expect(mockSendInput).toHaveBeenCalled();
+        const call = (mockSendInput as any).mock.calls[0];
+        expect(call[0]).toBe('t1');
+        expect(call[1]).toMatch(/\x1b\[<64;\d+;\d+M/);
+      });
     });
   });
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -119,6 +119,8 @@ export interface PartialTerminalSettings {
   theme?: string;
   cursorBlink?: boolean;
   scrollback?: number;
+  scrollSensitivity?: number;
+  fastScrollSensitivity?: number;
   bellSound?: boolean;
   altClickMovesCursor?: boolean;
   multiCursorModifier?: string;
@@ -378,6 +380,8 @@ export const CONFIG_KEYS = {
 
   // terminal.integrated section
   ALT_CLICK_MOVES_CURSOR: 'altClickMovesCursor',
+  MOUSE_WHEEL_SCROLL_SENSITIVITY: 'mouseWheelScrollSensitivity',
+  FAST_SCROLL_SENSITIVITY: 'fastScrollSensitivity',
   SHELL_WINDOWS: 'shell.windows',
   SHELL_OSX: 'shell.osx',
   SHELL_LINUX: 'shell.linux',

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -121,6 +121,7 @@ export interface PartialTerminalSettings {
   scrollback?: number;
   scrollSensitivity?: number;
   fastScrollSensitivity?: number;
+  legacyMouseWheelEncoding?: boolean;
   bellSound?: boolean;
   altClickMovesCursor?: boolean;
   multiCursorModifier?: string;

--- a/src/webview/managers/ConfigManager.ts
+++ b/src/webview/managers/ConfigManager.ts
@@ -114,6 +114,7 @@ export class ConfigManager implements IConfigManager {
     cursorBlink: true,
     scrollSensitivity: 1,
     fastScrollSensitivity: 5,
+    legacyMouseWheelEncoding: false,
     enableCliAgentIntegration: true,
     enableTerminalHeaderEnhancements: true,
     // Terminal profiles (will be populated from VS Code settings)

--- a/src/webview/managers/ConfigManager.ts
+++ b/src/webview/managers/ConfigManager.ts
@@ -112,6 +112,8 @@ export class ConfigManager implements IConfigManager {
     fontFamily: 'Consolas, "Courier New", monospace',
     theme: 'auto',
     cursorBlink: true,
+    scrollSensitivity: 1,
+    fastScrollSensitivity: 5,
     enableCliAgentIntegration: true,
     enableTerminalHeaderEnhancements: true,
     // Terminal profiles (will be populated from VS Code settings)

--- a/src/webview/managers/UIManager.ts
+++ b/src/webview/managers/UIManager.ts
@@ -525,6 +525,16 @@ export class UIManager extends BaseManager implements IUIManager {
       uiLogger.debug(`Applied scrollback: ${settings.scrollback}`);
     }
 
+    // Apply scroll speed
+    if (settings.scrollSensitivity !== undefined) {
+      terminal.options.scrollSensitivity = settings.scrollSensitivity;
+      uiLogger.debug(`Applied scroll sensitivity: ${settings.scrollSensitivity}`);
+    }
+    if (settings.fastScrollSensitivity !== undefined) {
+      terminal.options.fastScrollSensitivity = settings.fastScrollSensitivity;
+      uiLogger.debug(`Applied fast scroll sensitivity: ${settings.fastScrollSensitivity}`);
+    }
+
     // Bell sound is not supported in xterm.js options
     // Terminal bell handling would be implemented differently
   }

--- a/src/webview/services/TerminalCreationService.ts
+++ b/src/webview/services/TerminalCreationService.ts
@@ -154,7 +154,9 @@ export class TerminalCreationService implements Disposable {
     const focusService = new TerminalFocusService();
     const scrollbarService = new TerminalScrollbarService();
     const scrollIndicatorService = new TerminalScrollIndicatorService();
-    this.mouseTrackingService = new MouseTrackingService();
+    this.mouseTrackingService = new MouseTrackingService(
+      () => coordinator.getManagers().config.getCurrentSettings().legacyMouseWheelEncoding === true
+    );
 
     this.appearanceService = new TerminalAppearanceService({
       coordinator: coordinator as any,

--- a/src/webview/services/terminal/MouseTrackingService.ts
+++ b/src/webview/services/terminal/MouseTrackingService.ts
@@ -56,6 +56,17 @@ export class MouseTrackingService {
   private readonly terminals: Map<string, MouseTrackingState> = new Map();
 
   /**
+   * @param useLegacyWheelEncoding - Encode wheel reports here rather than
+   *   letting xterm.js do it. xterm.js applies scrollSensitivity, converts
+   *   pixel deltas to whole lines with carry-over, and honours the active
+   *   mouse protocol; attachWheelHandler does none of that and emits one
+   *   report per DOM event, which on a trackpad is dozens per flick.
+   *   Read on each mode change, so it takes effect the next time an
+   *   application turns mouse tracking on.
+   */
+  constructor(private readonly useLegacyWheelEncoding: () => boolean = () => false) {}
+
+  /**
    * Setup mouse tracking detection for a terminal
    *
    * @param terminal - xterm.js Terminal instance
@@ -109,10 +120,12 @@ export class MouseTrackingService {
               // First mouse mode enabled - disable native scrolling
               viewport.style.overflow = 'hidden';
 
-              // Attach wheel handler to screen element (where wheel events go)
-              const wheelTarget = screenElement || terminalElement || viewport;
-              state.wheelTarget = wheelTarget;
-              this.attachWheelHandler(terminal, terminalId, wheelTarget, state);
+              if (this.useLegacyWheelEncoding()) {
+                // Attach wheel handler to screen element (where wheel events go)
+                const wheelTarget = screenElement || terminalElement || viewport;
+                state.wheelTarget = wheelTarget;
+                this.attachWheelHandler(terminal, terminalId, wheelTarget, state);
+              }
 
               terminalLogger.info(
                 `[MouseTracking] Mode ${mode} enabled for ${terminalId}, native scroll disabled`


### PR DESCRIPTION
## Summary

Rebases and lands the remaining contributor scrolling fixes from @edusperoni after the earlier contributor PRs merged.

This is **#672 + #674**, replayed onto current `main` so the `SettingsSyncService` conflict with #669 is resolved.

### #672 — honour `terminal.integrated` scroll sensitivity

- Read `mouseWheelScrollSensitivity` / `fastScrollSensitivity` from `terminal.integrated`
- Forward them to the WebView and apply them to `terminal.options`
- Defaults stay `1` / `5` (same as VS Code and the previous hardcodes)

### #674 — let xterm.js encode mouse-tracking wheel reports

- When an app enables mouse tracking, keep `overflow: hidden` but stop encoding one SGR report per DOM wheel event
- Trackpad flicks were becoming dozens of scroll steps; xterm.js already applies sensitivity, line accumulation, and protocol rules
- Old encoder remains behind `secondaryTerminal.legacyMouseWheelEncoding` (default `false`)

## Why a new PR

#672 / #674 targeted `main` from before #669 / #676 landed. Both were `CONFLICTING` after those merges. This rebases them onto current `main`; original authorship is preserved on the cherry-picked commits.

Original PRs:
- https://github.com/s-hiraoku/vscode-sidebar-terminal/pull/672
- https://github.com/s-hiraoku/vscode-sidebar-terminal/pull/674

## Validation

- `npm run test:unit` (run after opening this PR)
- Existing unit tests from the original PRs are kept, plus the #669 keybinding assertions

## Original author

Eduardo Speroni (@edusperoni)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable terminal scroll and fast-scroll sensitivity.
  * Added an optional legacy mouse-wheel encoding setting for improved scrolling compatibility in full-screen terminal applications.
  * Settings now synchronize and apply automatically to the terminal.

* **Bug Fixes**
  * Improved mouse-wheel handling by using native terminal behavior by default, while preserving legacy encoding when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->