### PR TITLE
chore(deps): update mocha to 11.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10645,9 +10645,9 @@
       "optional": true
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
+      "integrity": "sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==",
       "dev": true,
       "dependencies": {
         "browser-stdout": "^1.3.1",


### PR DESCRIPTION
## Summary

Replays renovate #656 onto current `main` after lockfile conflicts from the other dependency merges.

- mocha `11.7.5` → `11.8.0` in `package-lock.json` only
- `package.json` stays on `^11.7.5`

Original PR: https://github.com/s-hiraoku/vscode-sidebar-terminal/pull/656

## Validation

Lockfile-only patch. Original #656 CI was green before it conflicted.