### PR TITLE
test(release): update ReleaseReadiness for 1.2.0

### DIFF
--- a/src/test/vitest/unit/release/ReleaseReadiness.test.ts
+++ b/src/test/vitest/unit/release/ReleaseReadiness.test.ts
@@ -68,7 +68,7 @@ const findProductionConsoleCalls = (): string[] => {
   });
 };
 
-describe('1.1.0 release readiness', () => {
+describe('1.2.0 release readiness', () => {
   it('uses stable release package metadata', () => {
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')
@@ -78,25 +78,25 @@ describe('1.1.0 release readiness', () => {
       keywords: string[];
     };
 
-    expect(packageJson.version).toBe('1.1.0');
+    expect(packageJson.version).toBe('1.2.0');
     expect(packageJson.description).toBe(
       'Sidebar terminal for VS Code with AI agent awareness (Claude Code, Copilot, Gemini, Codex, Antigravity), split views, session persistence, and full IME support.'
     );
     expect(packageJson.keywords).toEqual(expectedKeywords);
   });
 
-  it('documents the 1.1.0 release at the top of the changelog', () => {
+  it('documents the 1.2.0 release at the top of the changelog', () => {
     const changelog = fs.readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
     const releaseHeading =
-      /^## \[1\.1\.0\]\(https:\/\/github\.com\/s-hiraoku\/vscode-sidebar-terminal\/compare\/v1\.0\.0\.\.\.v1\.1\.0\) \(\d{4}-\d{2}-\d{2}\)/m;
+      /^## \[1\.2\.0\]\(https:\/\/github\.com\/s-hiraoku\/vscode-sidebar-terminal\/compare\/v1\.1\.0\.\.\.v1\.2\.0\) \(\d{4}-\d{2}-\d{2}\)/m;
     const releaseMatch = changelog.match(releaseHeading);
-    const previousReleaseHeading = '## [1.0.0]';
+    const previousReleaseHeading = '## [1.1.0]';
 
     expect(releaseMatch).not.toBeNull();
     expect(releaseMatch!.index!).toBeLessThan(changelog.indexOf(previousReleaseHeading));
-    expect(changelog).toContain('dispose terminal auto-save listeners');
+    expect(changelog).toContain('add Antigravity CLI detection');
     expect(changelog).toContain(
-      'https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/057a5bd23f5e8e08d78d5d906d47b4cad227505b'
+      'https://github.com/s-hiraoku/vscode-sidebar-terminal/commit/c565d67390dc888f94d2e7f3a338ffdec2ff1ac7'
     );
   });
 


### PR DESCRIPTION
## Summary
1.2.0 のリリース後、CI の `test (macos-latest)` が `ReleaseReadiness.test.ts` の 1.1.0 固定アサーションで失敗しています。タグ `v1.2.0` はまだ打っていません。

この PR はリリース準備テストだけを 1.2.0 に合わせます。

## Changes
- `package.json` の期待バージョンを `1.2.0` に更新
- CHANGELOG 先頭見出しを `## [1.2.0](...compare/v1.1.0...v1.2.0)` に更新
- 1.2.0 の追加内容（Antigravity CLI detection）を検証
- 直前リリースは `1.1.0` のまま

## Impact
- ユーザー向け機能変更なし
- 1.2.0 タグ前の品質ゲートを通すための修正

## Validation
- `npm run test:unit`: 4816 passed / 98 skipped
- CI の macOS / Windows 通過を確認（Ubuntu timeout は既知フレーク）